### PR TITLE
literate developments for ICFP17: multiple binding form

### DIFF
--- a/examples/paper/01-base-language.makam
+++ b/examples/paper/01-base-language.makam
@@ -56,8 +56,45 @@ typeof (lam _ (fun x => x)) T' ?
    type with a naive implementation of unification fails as expected.
 *)
 
-typeof (lam T (fun x => app x x)) T' ?
+typeof (lam _ (fun x => app x x)) T' ?
 
 (*
 >> Impossible.
+*)
+
+(* Other than supporting higher-order abstract syntax, λProlog also supports polymorphic types and higher-order
+   predicates, in a matter akin to traditional functional programming languages. For example, we can define the
+   polymorphic `list` type, and an accompanying `map` higher-order predicate, as follows:
+*)
+
+%extend tmp. (* NOTE: temporary namespace so that we can still use the standard `list` type in what follows. *)
+
+list : type -> type.
+
+nil : list A.
+cons : A -> list A -> list A.
+
+map : (A -> B -> prop) -> list A -> list B -> prop.
+map P nil nil.
+map P (cons X XS) (cons Y YS) <- P X Y, map P XS YS.
+
+%end.
+
+(* Using the meta-level list type, we can encode object-level constructs such as tuples and product types 
+   directly: *)
+
+tuple : list term -> term.
+product : list typ -> typ.
+
+(* Similarly we can use the `map` predicate to define the typing relation for tuples. *)
+
+typeof (tuple ES) (product TS) <-
+  map typeof ES TS.
+
+(* Executing a query like: *)
+
+typeof (lam _ (fun x => lam _ (fun y => tuple (cons x (cons y nil))))) T ?
+
+(*
+>> T := arrow T1 (arrow T2 (product (cons T1 (cons T2 nil))))
 *)

--- a/examples/paper/01-base-language.makam
+++ b/examples/paper/01-base-language.makam
@@ -76,7 +76,7 @@ cons : A -> list A -> list A.
 
 map : (A -> B -> prop) -> list A -> list B -> prop.
 map P nil nil.
-map P (cons X XS) (cons Y YS) <- P X Y, map P XS YS.
+map P (cons X XS) (cons Y YS) :- P X Y, map P XS YS.
 
 %end.
 
@@ -88,7 +88,7 @@ product : list typ -> typ.
 
 (* Similarly we can use the `map` predicate to define the typing relation for tuples. *)
 
-typeof (tuple ES) (product TS) <-
+typeof (tuple ES) (product TS) :-
   map typeof ES TS.
 
 (* Executing a query like: *)
@@ -96,5 +96,25 @@ typeof (tuple ES) (product TS) <-
 typeof (lam _ (fun x => lam _ (fun y => tuple (cons x (cons y nil))))) T ?
 
 (*
+   yields:
+
 >> T := arrow T1 (arrow T2 (product (cons T1 (cons T2 nil))))
 *)
+
+(* So far we have only introduced the predicate `typeof` for typing. In the same way,
+   we can introduce a predicate for evaluating terms, capturing the dynamic semantics of
+   the language. *)
+
+eval : term -> term -> prop.
+
+(* Most of the rules are straightforward, following standard practice for big-step semantics.
+   We assume a call-by-value evaluation strategy. *)
+
+eval (lam T F) (lam T F).
+eval (tuple ES) (tuple VS) :- map eval ES TS.
+
+(* For the beta-redex case, function application for higher-order abstract syntax gives us
+   capture-avoiding substitution directly: *)
+
+eval (app E E') V'' :-
+  eval E (lam _ F), eval E' V', eval (F V') V''.

--- a/examples/paper/02-binding-forms.makam
+++ b/examples/paper/02-binding-forms.makam
@@ -106,8 +106,8 @@ openmany F P :-
    it therefore can be read as existential quantification. Metavariables are allowed
    to capture all the free variables in scope at the point where there are introduced.
    For most of them, introduced implicitly in each clause, this means the free variables
-   in scope when the clause is used. In this case however we would like to permit `Body`
-   to capture the fresh variables introduced by the `intromany` predicate too, hence the
+   in scope when the clause is used. In this case however it is necessary that `Body`
+   can capture the fresh variables introduced by the `intromany` predicate too, hence the
    explicit metavariable introduction.
 *)
 

--- a/examples/paper/02-binding-forms.makam
+++ b/examples/paper/02-binding-forms.makam
@@ -104,7 +104,7 @@ openmany F P :-
 
    The square bracket notation, used above in `[Body]`, introduces a new metavariable;
    it therefore can be read as existential quantification. Metavariables are allowed
-   to capture all the free variables in scope at the point where there are introduced.
+   to capture all the free variables in scope at the point where they are introduced.
    For most of them, introduced implicitly in each clause, this means the free variables
    in scope when the clause is used. In this case however it is necessary that `Body`
    can capture the fresh variables introduced by the `intromany` predicate too, hence the
@@ -124,10 +124,10 @@ typeof (lammany F) (arrowmany TS T') :-
 typeof (lammany (bindnext (fun x => bindnext (fun y => bindbase (tuple [x, y]))))) T ?
 
 (*
->> T := arrowmany [ T1, T2 ] (product [ T1, T2 ])
+>> T := arrowmany [T1, T2] (product [T1, T2])
 *)
 
-(* Adding the corresponding `appmany` construct for simultaneous application is straight-forward.
+(* Adding the corresponding `appmany` construct for simultaneous application is straightforward.
    We can use the `applymany` predicate defined above to encode simultaneous substitution for the
    evaluation rule. *)
 

--- a/examples/paper/02-binding-forms.makam
+++ b/examples/paper/02-binding-forms.makam
@@ -126,3 +126,51 @@ typeof (lammany (bindnext (fun x => bindnext (fun y => bindbase (tuple [x, y])))
 (*
 >> T := arrowmany [ T1, T2 ] (product [ T1, T2 ])
 *)
+
+(* Adding the corresponding `appmany` construct for simultaneous application is straight-forward.
+   We can use the `applymany` predicate defined above to encode simultaneous substitution for the
+   evaluation rule. *)
+
+appmany : term -> list term -> term.
+
+typeof (appmany E ES) T' :-
+  typeof E (arrowmany TS T'),
+  map typeof ES TS.
+
+eval (lammany F) (lammany F).
+
+eval (appmany E ES) V' :-
+  eval E (lammany F),
+  map eval ES VS,
+  applymany F VS E',
+  eval E' V'.
+
+(* We can use the `bindmany` type to encode other constructs, such as mutually recursive definitions,
+   like the `let rec` construct of ML. In that case, we can capture the right binding structure by
+   introducing a number of variables simultaneously, accessible both when giving the (same number of)
+   definitions and the body of the construct.
+
+   We can therefore encode a `let rec` construct of the form:
+   `let rec f = f_def and g = g_def in body`
+   as
+   `letrec (bindnext (fun f => bindnext (fun g => bindbase ([f_def, g_def]))))
+     (bindnext (fun f => bindnext (fun g => bindbase body)))`
+*)
+
+letrec : bindmany term (list term) -> bindmany term term -> term.
+
+typeof (letrec XS_Defs XS_Body) T' :-
+  openmany XS_Defs (pfun xs defs =>
+    assumemany typeof xs TS (map typeof defs TS)
+  ),
+  openmany XS_Body (pfun xs body =>
+    assumemany typeof xs TS (typeof body T')
+  ).
+
+(* Still, even though this encoding matches the binding structure correctly, it is unsatisfying,
+   as it does not guarantee that the same number of variables are introduced in both cases and
+   that the same number of definitions are given. Though this requirement is enforced at the
+   level of the typing rules, it would be better if we could enforce it at the syntax level.
+   This would require some sort of dependency though, which at first does not seem possible to
+   do in λProlog.
+*)

--- a/examples/paper/02-binding-forms.makam
+++ b/examples/paper/02-binding-forms.makam
@@ -1,0 +1,25 @@
+%use "01-base-language".
+
+(* As we've seen, single-variable binding as in the lambda abstraction can be handled easily through higher-order abstract
+   syntax. Let us now explore how to encode other forms of binding.
+   
+   As a first example, we will introduce multiple-argument functions as a distinct object-level construct, as opposed to
+   using currying. A first attempt at encoding such a construct could be to introduce a `list` of term variables at the same
+   time, as follows:
+*)
+
+lammany : (list term -> term) -> term.
+
+(* This is not exactly what we would like. The type `list term -> term` introduces a fresh local variable for the `list`
+   type, as opposed to a number of fresh local variables for the `term` type. Since the HOAS function space is parametric,
+   there is no way to even refer to the potential elements of the fresh `list` -- we can only refer to the list in full.
+
+   Instead, we would like a type that represents all types of the form:
+   term -> term
+   term -> (term -> term)
+   term -> (term -> (term -> term))
+   ...
+
+   Such a type can be directly encoded in λProlog, as follows:
+*)
+

--- a/examples/paper/02-binding-forms.makam
+++ b/examples/paper/02-binding-forms.makam
@@ -1,25 +1,128 @@
 %use "01-base-language".
 
-(* As we've seen, single-variable binding as in the lambda abstraction can be handled easily through higher-order abstract
-   syntax. Let us now explore how to encode other forms of binding.
+(* As we've seen, single-variable binding as in the lambda abstraction can be handled easily through
+   higher-order abstract syntax. Let us now explore how to encode other forms of binding.
    
-   As a first example, we will introduce multiple-argument functions as a distinct object-level construct, as opposed to
-   using currying. A first attempt at encoding such a construct could be to introduce a `list` of term variables at the same
-   time, as follows:
+   As a first example, we will introduce multiple-argument functions as a distinct object-level
+   construct, as opposed to using currying. A first attempt at encoding such a construct could be to
+   introduce a `list` of term variables at the same time, as follows: 
 *)
 
 lammany : (list term -> term) -> term.
 
-(* This is not exactly what we would like. The type `list term -> term` introduces a fresh local variable for the `list`
-   type, as opposed to a number of fresh local variables for the `term` type. Since the HOAS function space is parametric,
-   there is no way to even refer to the potential elements of the fresh `list` -- we can only refer to the list in full.
+(* However, this type does not correspond to the construct we are trying to encode. The type `list
+   term -> term` introduces a fresh local variable for the `list` type, as opposed to a number of
+   fresh local variables for the `term` type. Since the HOAS function space is parametric, there is
+   no way to even refer to the potential elements of the fresh `list` -- we can only refer to the
+   fresh list in full.
 
    Instead, we would like a type that represents all types of the form:
-   term -> term
-   term -> (term -> term)
-   term -> (term -> (term -> term))
-   ...
+   `term` (binding no variables)
+   `term -> term` (binding a single variable)
+   `term -> (term -> term)` (binding two variables)
+   `term -> (term -> (term -> term))` (binding three variables)
+   etc.
 
-   Such a type can be directly encoded in λProlog, as follows:
+   We can encode such a type inductively in λProlog, as follows:
 *)
 
+bindmanyterms : type.
+bindbase : term -> bindmanyterms.
+bindnext : (term -> bindmanyterms) -> bindmanyterms.
+
+(* Furthermore, we can generalize the type that we are binding over, and the type of the body,
+   leading to a polymorphic type of the form: *)
+
+bindmany : type -> type -> type.
+bindbase : B -> bindmany A B.
+bindnext : (A -> bindmany A B) -> bindmany A B.
+
+(* With these, `lammany` can be encoded as: *)
+
+lammany : bindmany term term -> term.
+
+(* (As an aside: here we have allowed binding zero variables for presentation reasons. 
+   We could disallow binding zero variables by changing the `base` case to
+   require an argument of type `A -> B` instead of a `B`, similar to how we can specify
+   lists with at least one element inductively by replacing the `nil` constructor with
+   a constructor that requires an element.) *)
+
+(* How do we work with the `bindmany` type? For the built-in single binding type, we
+   used three operations:
+
+   - variable substitution, encoded through HOAS function application
+   - introducing a fresh variable, through the predicate form `x:term -> ...`
+   - introducing a new assumption, through the predicate form `P -> ...`
+
+   We can define three equivalent operations as predicates, for the multiple binding
+   case: *)
+
+(* a generalization of application, for substituting all the variables in a `bindmany` *)
+
+applymany : bindmany A B -> list A -> B -> prop.
+applymany (bindbase Body) [] Body.
+applymany (bindnext F) (HD :: TL) Body :-
+  applymany (F HD) TL Body.
+
+(* local introduction of multiple fresh variables at once within a predicate P; a list
+   of the variables is passed to it *)
+
+intromany : bindmany A B -> (list A -> prop) -> prop.
+intromany (bindbase _) P :- P [].
+intromany (bindnext F) P :-
+  (x:A -> intromany (F x) (fun tl => P (x :: tl))).
+
+(* local introduction of a number of assumptions of the form P X Y within a predicate
+   Q. This is intended to be used, for example, for introducing assumptions for predicates
+   such as `typeof`, taking a list of term variables and a list of types, in the same order.
+*)
+
+assumemany : (A -> B -> prop) -> list A -> list B -> prop -> prop.
+assumemany P [] [] Q :- Q.
+assumemany P (X :: XS) (Y :: YS) Q :- (P X Y -> assumemany P XS YS Q).
+
+(* These predicates are in exact correspondence with the operations we have available for
+   the built-in HOAS function type -- save for application being a predicate rather than
+   a term-level construct -- so we are able to reap the benefits of HOAS representations
+   for multiple bindings as well. 
+
+   For convenience, it is also useful to define another predicate that gives access to
+   both the variables introduced in a `bindmany` and the body of the construct as well.
+   This predicate combines `intromany`, for introducing the variables, with `applymany`,
+   for getting the body of the construct, and is defined as follows:
+*)
+
+openmany : bindmany A B -> (list A -> B -> prop) -> prop.
+openmany F P :-
+  intromany F (pfun xs => [Body] applymany F xs Body, P xs Body).
+
+(* Two notational idiosyncrasies here of Makam, the λProlog dialect we are using:
+
+   `pfun` is syntactic convenience for anonymous predicate literals, allowing to use
+   the normal syntax for propositions that we use elsewhere, i.e. in clause premises.
+   It is otherwise entirely equivalent to the `fun` construct for anonymous functions.
+
+   The square bracket notation, used above in `[Body]`, introduces a new metavariable;
+   it therefore can be read as existential quantification. Metavariables are allowed
+   to capture all the free variables in scope at the point where there are introduced.
+   For most of them, introduced implicitly in each clause, this means the free variables
+   in scope when the clause is used. In this case however we would like to permit `Body`
+   to capture the fresh variables introduced by the `intromany` predicate too, hence the
+   explicit metavariable introduction.
+*)
+
+(* We can now define the typing rule for `lammany` using these predicates, as follows: *)
+
+arrowmany : list typ -> typ -> typ.
+
+typeof (lammany F) (arrowmany TS T') :-
+  openmany F (fun xs body =>
+    assumemany typeof xs TS (typeof body T')).
+
+(* For example, the following query returns: *)
+
+typeof (lammany (bindnext (fun x => bindnext (fun y => bindbase (tuple [x, y]))))) T ?
+
+(*
+>> T := arrowmany [ T1, T2 ] (product [ T1, T2 ])
+*)

--- a/examples/paper/03-dependent-binding.makam
+++ b/examples/paper/03-dependent-binding.makam
@@ -1,6 +1,6 @@
 %use "02-binding-forms".
 
-(* Sneak peek: not much commentary here, just showing what's possible. *)
+(* Sneak peek: work-in-progress and not much commentary here, just roughly showing what's possible. *)
 
 (* dbind A T B: dependently-typed binding of many A's into a B; T is a tuple-type representing the type of substitutions. *)
 
@@ -53,5 +53,23 @@ patt : type -> type -> type.
 pattunit : patt T T.
 pattvar : patt (term * T) T.
 pattwild : patt T T.
-patttuple : patt T1 T2 -> patt T2 T3 -> patt T1 T3.
+patttuple : patt T1 T2 -> patt T2 T3 -> patt T1 T3. (* unfortunately can't do n-ary tuples.. *)
 
+single_branch_match : term -> patt T unit -> dbind term T term -> term.
+
+(*
+patt_to_term : patt T T'-> term -> T' -> T -> prop.
+patt_to_term pattunit eunit Subst Subst.
+patt_to_term pattvar X Subst (X, Subst).
+patt_to_term pattwild _ Subst Subst.
+patt_to_term (patttuple P1 P2) (tuple E1 E2) Subst3 Subst1 :-
+  patt_to_term P2 E2 Subst3 Subst2,
+  patt_to_term P1 E1 Subst2 Subst1.
+
+eval (single_branch_match Scrutinee Patt Body) V :-
+  patt_to_term Patt PattTerm unit UnifVars,
+  eq Scrutinee PattTerm, (* reuse unification *)
+  dbind.apply Body UnifVars Body',
+  eval Body' V.
+*)
+  

--- a/examples/paper/03-dependent-binding.makam
+++ b/examples/paper/03-dependent-binding.makam
@@ -53,7 +53,7 @@ patt : type -> type -> type.
 pattunit : patt T T.
 pattvar : patt (term * T) T.
 pattwild : patt T T.
-patttuple : patt T1 T2 -> patt T2 T3 -> patt T1 T3. (* unfortunately can't do n-ary tuples.. *)
+patttuple : patt T1 T2 -> patt T2 T3 -> patt T1 T3.
 
 single_branch_match : term -> patt T unit -> dbind term T term -> term.
 
@@ -72,4 +72,18 @@ eval (single_branch_match Scrutinee Patt Body) V :-
   dbind.apply Body UnifVars Body',
   eval Body' V.
 *)
-  
+
+
+(* unfortunately n-ary tuples require their own list type: *)
+pattlist : type -> type -> type.
+pattnil : pattlist T T.
+pattcons : patt T1 T2 -> pattlist T2 T3 -> pattlist T1 T3.
+pattntuple : pattlist T1 T2 -> patt T1 T2.
+
+(*
+pattlist_to_termlist : pattlist T T' -> list term -> T' -> T -> prop.
+pattlist_to_termlist pattnil [] Subst Subst.
+pattlist_to_termlist (pattcons P PS) (T :: TS) Subst3 Subst1 <-
+  pattlist_to_termlist PS TS Subst3 Subst2,
+  patt_to_term P T Subst2 Subst1.
+*)

--- a/examples/paper/03-dependent-binding.makam
+++ b/examples/paper/03-dependent-binding.makam
@@ -16,7 +16,7 @@ apply : [A B] dbind A T B -> T -> B -> prop.
 open : [A B] dbind A T B -> (T -> B -> prop) -> prop.
 
 intro (dbind.one F) P :-
-  (x:A -> intro (F x) (fun t => P (x, t))).
+  (x:A -> intro (F x) (pfun t => P (x, t))).
 intro (dbind.none Body) P :- P unit.
 
 apply (dbind.one F) (X, XS) Body :-
@@ -45,8 +45,9 @@ typeof (letrec Defs Body) T' :-
 *)
 
 (* we can also use the same trick for linear contexts with no reordering, such as patterns.
-   The two type arguments is the tuple of variables that we start with, and the second one
-   the tuple of variables we're left with. *)
+   Taking patterns as an example, we need two type arguments: one representing the tuple
+   of variables that we start with, and another one for representing the tuple of variables
+   we're left with. *)
 
 patt : type -> type -> type.
 

--- a/examples/paper/03-dependent-binding.makam
+++ b/examples/paper/03-dependent-binding.makam
@@ -1,0 +1,57 @@
+%use "02-binding-forms".
+
+(* Sneak peek: not much commentary here, just showing what's possible. *)
+
+(* dbind A T B: dependently-typed binding of many A's into a B; T is a tuple-type representing the type of substitutions. *)
+
+dbind : type -> type -> type -> type.
+
+%extend dbind.
+
+one : (A -> dbind A T B) -> dbind A (A * T) B.
+none : B -> dbind A unit B.
+
+intro : [A B] dbind A T B -> (T -> prop) -> prop.
+apply : [A B] dbind A T B -> T -> B -> prop.
+open : [A B] dbind A T B -> (T -> B -> prop) -> prop.
+
+intro (dbind.one F) P :-
+  (x:A -> intro (F x) (fun t => P (x, t))).
+intro (dbind.none Body) P :- P unit.
+
+apply (dbind.one F) (X, XS) Body :-
+  apply (F X) XS Body.
+apply (dbind.none Body) unit Body.
+
+open (dbind.one F) P :-
+  (x:A -> open (F x) (fun t body => P (x, t) body)).
+open (dbind.none Body) P :- P unit Body.  
+
+%end.
+
+(*
+something like that should work:
+(though letrec is probably not the best example)
+
+letrec : dbind term T T -> dbind term T term -> term.
+typeof (letrec Defs Body) T' :-
+  dbind.open Defs (pfun xs defs =>
+    tuple.toList xs xsL,
+    assumemany typeof xsL TS (structural typeof defs TS)
+  ),
+  dbind.open Body (pfun xs body =>
+    tuple.toList xs xsL,
+    assumemany typeof xsL TS (typeof body T')).
+*)
+
+(* we can also use the same trick for linear contexts with no reordering, such as patterns.
+   The two type arguments is the tuple of variables that we start with, and the second one
+   the tuple of variables we're left with. *)
+
+patt : type -> type -> type.
+
+pattunit : patt T T.
+pattvar : patt (term * T) T.
+pattwild : patt T T.
+patttuple : patt T1 T2 -> patt T2 T3 -> patt T1 T3.
+

--- a/init.makam
+++ b/init.makam
@@ -3,3 +3,4 @@
 %directory "examples/small".
 %directory "examples/peg".
 %directory "examples/experiments".
+%directory "examples/paper".


### PR DESCRIPTION
Added a description and examples of how to do multiple binding in Makam. The examples used are `lammany` and `letrec`.

Also includes some WIP work for dependently-typed binding forms, where we capture information about how many things we are binding in the type, allowing dependency across various constructs (actually carrying the type of substitutions as an n-tuple type seems to be the best way to go). For example, we can encode `letrec` in such a way that we are guaranteed to have the same number of definitions as bindings, through syntax alone. Ad-hoc polymorphism at the rule level makes this very pleasant to work with. (This has been going through my mind for a while, and it turns out it's possible in Makam/λProlog.) That's still very rough, but I think if we clean this up and make it presentable it could be part of the paper.

@achlipala Thoughts?
