### PR TITLE
switch type annotation for ad hoc polymorphism

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -16,10 +16,9 @@ XOCamlBuildExtraArgs:  -byte-plugin
 SourceRepository master
   Type:     git
   Location: https://github.com/astampoulis/makam.git
-  
+
 Executable "makam-bin"
   Path:       .
   MainIs:     toploop/nativerepl.ml
   CompiledObject: best
   Install:        false
-  

--- a/examples/big/f2tal.makam
+++ b/examples/big/f2tal.makam
@@ -67,7 +67,7 @@ typeof_ (appt E T) (T' T) <-
 typeof_ (tup ES) (ttup TS) <-
   map typeof ES TS.
 
-nth : [A] list A -> nat -> A -> prop.
+nth : list A -> nat -> A -> prop.
 nth (HD :: TL) nzero HD.
 nth (HD :: TL) (nsucc N) R <- nth TL N R.
 
@@ -589,9 +589,9 @@ translatec_val (valk (tupk VS) T) (valc (tupc VS') T') <-
   translatec_typ T T'.
 
 
-valfv : A -> list B -> prop.
-valfv_aux : dyn -> list B -> list B -> prop.
-valfv_avoid : A -> prop.
+valfv : {A} A -> list B -> prop.
+valfv_aux : {B} dyn -> list B -> list B -> prop.
+valfv_avoid : {A} A -> prop.
 
 valfv_aux Input Cur Res <-
   caseguard Input
@@ -606,8 +606,8 @@ valfv X Res' <-
 
 (* ------------------ fv *)
 
-foldr_inat : [A B] (nat -> A -> B -> B -> prop) -> list A -> B -> B -> prop.
-foldr_inat_aux : [A B] (nat -> A -> B -> B -> prop) -> nat -> list A -> B -> B -> prop.
+foldr_inat : (nat -> A -> B -> B -> prop) -> list A -> B -> B -> prop.
+foldr_inat_aux : (nat -> A -> B -> B -> prop) -> nat -> list A -> B -> B -> prop.
 
 foldr_inat_aux P N nil S S.
 foldr_inat_aux P N (cons HD TL) S S'' <- foldr_inat_aux P (nsucc N) TL S S', P N HD S' S''.
@@ -705,7 +705,7 @@ examplec : termc -> prop.
 `( define examplec (fun res => {prop| examplek E, translatec_prog E res |}) ).
 
 
-erasetypes : A -> A -> prop.
+erasetypes : {A} A -> A -> prop.
 erasetypes (X : typc) (X : typc).
 erasetypes (dcval X Y) (dcval X' Y') <- erasetypes X X', (x:bvalc -> erasetypes (Y x) (Y' x)).
 erasetypes (dcproj I V Y) (dcproj I V' Y') <- erasetypes V V', (x:bvalc -> erasetypes (Y x) (Y' x)).

--- a/examples/big/f2tal.makam
+++ b/examples/big/f2tal.makam
@@ -589,9 +589,9 @@ translatec_val (valk (tupk VS) T) (valc (tupc VS') T') <-
   translatec_typ T T'.
 
 
-valfv : {A} A -> list B -> prop.
-valfv_aux : {B} dyn -> list B -> list B -> prop.
-valfv_avoid : {A} A -> prop.
+valfv : [A] A -> list B -> prop.
+valfv_aux : [B] dyn -> list B -> list B -> prop.
+valfv_avoid : [A] A -> prop.
 
 valfv_aux Input Cur Res <-
   caseguard Input
@@ -705,7 +705,7 @@ examplec : termc -> prop.
 `( define examplec (fun res => {prop| examplek E, translatec_prog E res |}) ).
 
 
-erasetypes : {A} A -> A -> prop.
+erasetypes : [A] A -> A -> prop.
 erasetypes (X : typc) (X : typc).
 erasetypes (dcval X Y) (dcval X' Y') <- erasetypes X X', (x:bvalc -> erasetypes (Y x) (Y' x)).
 erasetypes (dcproj I V Y) (dcproj I V' Y') <- erasetypes V V', (x:bvalc -> erasetypes (Y x) (Y' x)).

--- a/examples/big/ocaml-binders-everywhere.makam
+++ b/examples/big/ocaml-binders-everywhere.makam
@@ -437,7 +437,7 @@ constrdef False csdefunit bool nil.
 sigof : modstruct -> modsig -> prop.
 sigof_item : stritem -> bindany (list prop) -> listbindany sigitem -> prop.
 
-sigof_item_cast : {X} stritem -> X -> listbindany sigitem -> prop.
+sigof_item_cast : [X] stritem -> X -> listbindany sigitem -> prop.
 sigof_item X Y Z <-
   sigof_item_cast X Y' Z,
   bindany_cast Y' Y.

--- a/examples/big/ocaml-binders-everywhere.makam
+++ b/examples/big/ocaml-binders-everywhere.makam
@@ -437,7 +437,7 @@ constrdef False csdefunit bool nil.
 sigof : modstruct -> modsig -> prop.
 sigof_item : stritem -> bindany (list prop) -> listbindany sigitem -> prop.
 
-sigof_item_cast : stritem -> X -> listbindany sigitem -> prop.
+sigof_item_cast : {X} stritem -> X -> listbindany sigitem -> prop.
 sigof_item X Y Z <-
   sigof_item_cast X Y' Z,
   bindany_cast Y' Y.

--- a/examples/big/ocaml.makam
+++ b/examples/big/ocaml.makam
@@ -237,7 +237,7 @@ typeof (projrec E Field) T <-
   typapply TC TS T,
   once (typeof E (tbase Tbase TS)).
 
-guess_type : [A] map string A -> string -> prop.
+guess_type : map string A -> string -> prop.
 guess_type (map ( (Key, _) :: _ )) Tbase <-
   field_def Key _ Tbase.
 

--- a/examples/big/urweb.makam
+++ b/examples/big/urweb.makam
@@ -390,7 +390,7 @@ dynteq (dyn T) (dyn T') <-
    then teq X Y
    else structural dynteq (dyn T) (dyn T')).
 
-letdef : string -> E -> cmd -> prop.
+letdef : {E} string -> E -> cmd -> prop.
 letdef X E (cmd_many [ cmd_newterm X (_ : term),
                        cmd_stage (fun res => {prop|
 	                  refl.lookup X C,
@@ -398,7 +398,7 @@ letdef X E (cmd_many [ cmd_newterm X (_ : term),
   typeof E T.
 
 
-typedef : string -> T -> cmd -> prop.
+typedef : {T} string -> T -> cmd -> prop.
 typedef X T (cmd_many [ cmd_newterm X (_ : typ),
                         cmd_stage (fun res => {prop|
 	                  refl.lookup X C,

--- a/examples/big/urweb.makam
+++ b/examples/big/urweb.makam
@@ -390,7 +390,7 @@ dynteq (dyn T) (dyn T') <-
    then teq X Y
    else structural dynteq (dyn T) (dyn T')).
 
-letdef : {E} string -> E -> cmd -> prop.
+letdef : [E] string -> E -> cmd -> prop.
 letdef X E (cmd_many [ cmd_newterm X (_ : term),
                        cmd_stage (fun res => {prop|
 	                  refl.lookup X C,
@@ -398,7 +398,7 @@ letdef X E (cmd_many [ cmd_newterm X (_ : term),
   typeof E T.
 
 
-typedef : {T} string -> T -> cmd -> prop.
+typedef : [T] string -> T -> cmd -> prop.
 typedef X T (cmd_many [ cmd_newterm X (_ : typ),
                         cmd_stage (fun res => {prop|
 	                  refl.lookup X C,

--- a/examples/big/veriml.makam
+++ b/examples/big/veriml.makam
@@ -56,7 +56,7 @@ ctxparam    : cvar -> (svar -> listbindmany hol.term hol.term A) -> ctx A. (* Φ
 
 (* Typing judgements *)
 ctxofsubst_var : svar -> cvar -> prop.            (* ⊢ id_φ : [φ]() *)
-ctxofsubst     : [A] subst -> ctx A -> prop.      (* ⊢ σ : Φ    – actually ⊢ σ : [Φ]() *)
+ctxofsubst     : subst -> ctx A -> prop.      (* ⊢ σ : Φ    – actually ⊢ σ : () *)
 ctypeof_var    : cvar -> ctype -> prop.           (* ⊢ X : K *)
 ctypeof        : cexpr -> ctype -> prop.          (* ⊢ T : K *)
 
@@ -90,7 +90,7 @@ ctxofsubst (substparam ID_Phi TL) (ctxparam Phi Rest) <-
      produces the identity substitution for Φ based on these fresh variables
      and runs P with that identity substitution *)
 
-ctx_open : [A] ctx A -> (subst -> prop) -> prop.
+ctx_open : ctx A -> (subst -> prop) -> prop.
 ctx_open (ctxconcrete Phi) F <-
   listbindmany_newvars Phi (fun vars => {prop| [Typs]
    listbindmany_getinfo Phi vars Typs,
@@ -105,7 +105,7 @@ ctx_open (ctxparam Phi Rest) F <-
      given an explicit substitution for Φ,
      return the body of the contextual term *)
 
-ctx_body : [A] ctx A -> subst -> A -> prop.
+ctx_body : ctx A -> subst -> A -> prop.
 ctx_body (ctxconcrete PhiA) (substconcrete Sigma) A <-
    listbindmany_apply PhiA Sigma A.
 ctx_body (ctxparam Phi Rest) (substparam IDPhi RestSigma) A <-
@@ -113,7 +113,7 @@ ctx_body (ctxparam Phi Rest) (substparam IDPhi RestSigma) A <-
 
 (* ctx_get ([Φ]a) id{Φ} ([Φ]())
      removes the body of the context, useful for testing contexts for equality *)
-ctx_get : [A] ctx A -> subst -> ctx unit -> prop.
+ctx_get : ctx A -> subst -> ctx unit -> prop.
 ctx_get (ctxconcrete (lbnil _)) (substconcrete nil) (ctxconcrete (lbnil unit)).
 ctx_get (ctxconcrete (lbcons HDt Rest)) (substconcrete (cons HD TL))
         (ctxconcrete (lbcons HDt Rest')) <-
@@ -123,7 +123,7 @@ ctx_get (ctxparam Phi Rest) (substparam IDphi Sigma')
   ctx_get (ctxconcrete (Rest IDphi)) (substconcrete Sigma') (ctxconcrete (Rest' IDphi)).
 
 
-ctx_get_partial : [A] ctx A -> subst -> ctx unit -> ctx A -> prop.
+ctx_get_partial : ctx A -> subst -> ctx unit -> ctx A -> prop.
 ctx_get_partial A (substconcrete nil) (ctxconcrete (lbnil unit)) A.
 ctx_get_partial (ctxconcrete (lbcons HDt Rest)) (substconcrete (cons HD TL))
         (ctxconcrete (lbcons HDt Rest')) RestEnd <-
@@ -133,7 +133,7 @@ ctx_get_partial (ctxparam Phi Rest) (substparam IDphi Sigma')
   ctx_get_partial (ctxconcrete (Rest IDphi)) (substconcrete Sigma') (ctxconcrete (Rest' IDphi)) RestEnd.
 
 (* ctx_append ([Φ]a) ([Φ']b) ([Φ, Φ']b) *)
-ctx_append : [A B] ctx A -> listbindmany hol.term hol.term B -> ctx B -> prop.
+ctx_append : ctx A -> listbindmany hol.term hol.term B -> ctx B -> prop.
 ctx_append (ctxconcrete L) L' (ctxconcrete L'') <-
   listbindmany_append L L' L''.
 ctx_append (ctxparam Phi L) L' (ctxparam Phi L'') <-

--- a/examples/experiments/refactoring.makam
+++ b/examples/experiments/refactoring.makam
@@ -2,24 +2,24 @@
 
 %extend refltype.
 
-result : A -> B -> prop.
+result : {A B} A -> B -> prop.
 (result X Y) when refl.isfun X <- (x:A -> result (X x) Y).
 (result X Y) when not(refl.isfun X) <- typeq X Y.
 
-ispred : A -> prop.
+ispred : {A} A -> prop.
 ispred X <- result X (Z : prop).
 
 %end.
 
 
-dup_head : A -> B -> prop.
+dup_head : {A B} A -> B -> prop.
 (dup_head P P') when refl.isfun P <- (x:T -> dup_head (P x) P').
 (dup_head P P') when refl.isbaseterm P <- refl.headargs P Head _, refl.headname P PName, refl.lookup PName P'.
 
-dyncall : (A -> prop) -> dyn -> prop.
+dyncall : {A} (A -> prop) -> dyn -> prop.
 dyncall P (dyn X) <- refl.duphead P P', P' X.
 
-dyncall : (A -> B -> prop) -> dyn -> dyn -> prop.
+dyncall : {A B} (A -> B -> prop) -> dyn -> dyn -> prop.
 dyncall P (dyn X) (dyn Y) <- refl.duphead P P', P' X Y.
 
 (* ([X]allheads X, print X, map0 (dyncall printhead) X) ? *)

--- a/examples/experiments/refactoring.makam
+++ b/examples/experiments/refactoring.makam
@@ -2,24 +2,24 @@
 
 %extend refltype.
 
-result : {A B} A -> B -> prop.
+result : [A B] A -> B -> prop.
 (result X Y) when refl.isfun X <- (x:A -> result (X x) Y).
 (result X Y) when not(refl.isfun X) <- typeq X Y.
 
-ispred : {A} A -> prop.
+ispred : [A] A -> prop.
 ispred X <- result X (Z : prop).
 
 %end.
 
 
-dup_head : {A B} A -> B -> prop.
+dup_head : [A B] A -> B -> prop.
 (dup_head P P') when refl.isfun P <- (x:T -> dup_head (P x) P').
 (dup_head P P') when refl.isbaseterm P <- refl.headargs P Head _, refl.headname P PName, refl.lookup PName P'.
 
-dyncall : {A} (A -> prop) -> dyn -> prop.
+dyncall : [A] (A -> prop) -> dyn -> prop.
 dyncall P (dyn X) <- refl.duphead P P', P' X.
 
-dyncall : {A B} (A -> B -> prop) -> dyn -> dyn -> prop.
+dyncall : [A B] (A -> B -> prop) -> dyn -> dyn -> prop.
 dyncall P (dyn X) (dyn Y) <- refl.duphead P P', P' X Y.
 
 (* ([X]allheads X, print X, map0 (dyncall printhead) X) ? *)

--- a/examples/experiments/structural_rules.makam
+++ b/examples/experiments/structural_rules.makam
@@ -29,7 +29,7 @@
 %use generic.
 
 
-getrules : A -> list clause -> prop.
+getrules : {A} A -> list clause -> prop.
 
 
 clausegoal : clause -> (prop -> prop) -> prop.
@@ -64,7 +64,7 @@ test X <- demand_ifte (test X)
    easiest solution is to just have the real rules live in a different predicate. *)
 
 getrules test [ clause (test "aaa") success,
-                whenclause (test Z) {prop| eq X "b", append (X : string) Y Z |} success
+                whenclause (test Z) {prop| eq X "b", string.append (X : string) Y Z |} success
               ].
 
 `( testing.expect success (test "aaa") ).
@@ -95,7 +95,7 @@ change_strings (dyn [ "lala", "dada" ]) X ?
 (* fake rank-N polymorphism by duplicating a polymorphic head.
    (this forces generation of fresh type variables, which can be instantiated independently) *)
 
-dup_head : A -> B -> prop.
+dup_head : {A B} A -> B -> prop.
 (dup_head P P') when refl.isfun P <- (x:T -> dup_head (P x) P').
 (dup_head P P') when refl.isbaseterm P <- refl.headargs P Head _, refl.headname P PName, refl.lookup PName P'.
 
@@ -105,14 +105,14 @@ polyrec P X Y <- dup_head P P', P' X Y.
 dyncall : (A -> B -> prop) -> dyn -> dyn -> prop.
 dyncall P (dyn X) (dyn Y) <- polyrec P X Y.
 
-gentest : A -> B -> prop.
+gentest : {A B} A -> B -> prop.
 gentest "lala" 15.
 gentest 20 "qwerty".
 
 `( testing.expect success {prop| map (dyncall gentest) [dyn "lala", dyn 20] [dyn 15, dyn "qwerty"] |} ).
 
 
-structural : (A -> A -> prop) -> B -> B -> prop.
+structural : {A B} (A -> A -> prop) -> B -> B -> prop.
 
 (structural Rec X Y) when refl.isunif X, refl.isunif Y <-
   guardmany [ dyn X , dyn Y ] (polyrec Rec X Y).

--- a/examples/experiments/structural_rules.makam
+++ b/examples/experiments/structural_rules.makam
@@ -29,7 +29,7 @@
 %use generic.
 
 
-getrules : {A} A -> list clause -> prop.
+getrules : [A] A -> list clause -> prop.
 
 
 clausegoal : clause -> (prop -> prop) -> prop.
@@ -95,7 +95,7 @@ change_strings (dyn [ "lala", "dada" ]) X ?
 (* fake rank-N polymorphism by duplicating a polymorphic head.
    (this forces generation of fresh type variables, which can be instantiated independently) *)
 
-dup_head : {A B} A -> B -> prop.
+dup_head : [A B] A -> B -> prop.
 (dup_head P P') when refl.isfun P <- (x:T -> dup_head (P x) P').
 (dup_head P P') when refl.isbaseterm P <- refl.headargs P Head _, refl.headname P PName, refl.lookup PName P'.
 
@@ -105,14 +105,14 @@ polyrec P X Y <- dup_head P P', P' X Y.
 dyncall : (A -> B -> prop) -> dyn -> dyn -> prop.
 dyncall P (dyn X) (dyn Y) <- polyrec P X Y.
 
-gentest : {A B} A -> B -> prop.
+gentest : [A B] A -> B -> prop.
 gentest "lala" 15.
 gentest 20 "qwerty".
 
 `( testing.expect success {prop| map (dyncall gentest) [dyn "lala", dyn 20] [dyn 15, dyn "qwerty"] |} ).
 
 
-structural : {A B} (A -> A -> prop) -> B -> B -> prop.
+structural : [A B] (A -> A -> prop) -> B -> B -> prop.
 
 (structural Rec X Y) when refl.isunif X, refl.isunif Y <-
   guardmany [ dyn X , dyn Y ] (polyrec Rec X Y).

--- a/examples/lib/bindutils.makam
+++ b/examples/lib/bindutils.makam
@@ -34,8 +34,8 @@ bnil     : B -> bindmany A B.
        (bcons (fun x => bcons (fun y => bcons (fun z => body))))
  *)
 
-bindmanycast : {T} T -> bindmany A B -> prop.
-bindmanycast_aux : {T} T -> bindmany A B -> prop.
+bindmanycast : [T] T -> bindmany A B -> prop.
+bindmanycast_aux : [T] T -> bindmany A B -> prop.
 
 bindmanycast X R <- once(bindmanycast_aux X R).
 bindmanycast_aux (fun (x : A) => P x) (bcons (fun (x : A) => R x)) <-
@@ -129,8 +129,8 @@ bindany : type -> type.
 bcons  : (A -> bindany T) -> bindany T.
 bnil   : T -> bindany T.
 
-bindany_cast     : {T} T -> bindany A -> prop.
-bindany_cast_aux : {T} T -> bindany A -> prop.
+bindany_cast     : [T] T -> bindany A -> prop.
+bindany_cast_aux : [T] T -> bindany A -> prop.
 
 bindany_cast X R <- once(bindany_cast_aux X R).
 bindany_cast_aux (fun (x : B) => P x) (bcons (fun (x : B) => R x)) <-

--- a/examples/lib/bindutils.makam
+++ b/examples/lib/bindutils.makam
@@ -34,8 +34,8 @@ bnil     : B -> bindmany A B.
        (bcons (fun x => bcons (fun y => bcons (fun z => body))))
  *)
 
-bindmanycast : T -> bindmany A B -> prop.
-bindmanycast_aux : T -> bindmany A B -> prop.
+bindmanycast : {T} T -> bindmany A B -> prop.
+bindmanycast_aux : {T} T -> bindmany A B -> prop.
 
 bindmanycast X R <- once(bindmanycast_aux X R).
 bindmanycast_aux (fun (x : A) => P x) (bcons (fun (x : A) => R x)) <-
@@ -44,39 +44,37 @@ bindmanycast_aux (X : B) ((bnil X) : bindmany A B).
 
 
 
-bindmany_map : [A B C D]
-	      (A -> C -> prop) -> (B -> D -> prop) ->
-	      bindmany A B -> list C -> D -> prop.
+bindmany_map : (A -> C -> prop) -> (B -> D -> prop) ->
+	       bindmany A B -> list C -> D -> prop.
 bindmany_map P Q (bnil X)  nil          X' <- Q X X'.
 bindmany_map P Q (bcons (F : A -> bindmany A B)) (cons HD TL) X' <-
   (x:A -> P x HD -> bindmany_map P Q (F x) TL X').
 
-bindmany_endmap : [A B C]
-		  (B -> C -> prop) ->
+bindmany_endmap : (B -> C -> prop) ->
 		  bindmany A B -> C -> prop.
 bindmany_endmap P (bnil X) X' <- P X X'.
 bindmany_endmap P (bcons (F : A -> bindmany A B)) X' <-
   (x:A -> bindmany_endmap P (F x) X').
 
-bindmany_apply : [A B] bindmany A B -> list A -> B -> prop.
+bindmany_apply : bindmany A B -> list A -> B -> prop.
 bindmany_apply (bnil X)  nil          X.
 bindmany_apply (bcons F) (cons HD TL) X' <- bindmany_apply (F HD) TL X'.
 
 
-bindmany_newvars : [A B] bindmany A B -> (list A -> prop) -> prop.
-bindmany_newvars_aux : [A B] bindmany A B -> list A -> (list A -> prop) -> prop.
+bindmany_newvars : bindmany A B -> (list A -> prop) -> prop.
+bindmany_newvars_aux : bindmany A B -> list A -> (list A -> prop) -> prop.
 bindmany_newvars_aux (bnil _)                        Vars P <- reverse Vars Vars', P Vars'.
 bindmany_newvars_aux (bcons (F : A -> bindmany A B)) Vars P <-
   (x:A -> bindmany_newvars_aux (F x) (cons x Vars) P).
 bindmany_newvars X P <- bindmany_newvars_aux X nil P.
 
 
-bindmany_changetype : [A B C] bindmany A B -> bindmany C unit -> prop.
+bindmany_changetype : bindmany A B -> bindmany C unit -> prop.
 bindmany_changetype (bnil X) (bnil unit).
 bindmany_changetype (bcons (fun (x : A) => R x)) (bcons (fun (x : C) => R')) <-
   (x:A -> bindmany_changetype (R x) R').
 
-bindmany_fromlist : [A B] list A -> bindmany B unit -> prop.
+bindmany_fromlist : list A -> bindmany B unit -> prop.
 bindmany_fromlist (nil) (bnil unit).
 bindmany_fromlist (cons HD TL) ( (bcons (fun (x : A) => TL' x))
                                  : bindmany A unit ) <-
@@ -104,21 +102,19 @@ many_assume P AS BS Q <-
 
 bindmutrec : type -> type -> type.
 bindmutrec : bindmany A (list B) -> bindmutrec A B.
-bindmutrec_map : [A B C D]
-	        (A -> C -> prop) -> (B -> D -> prop) ->
-	        bindmutrec A B -> list C -> list D -> prop.
+bindmutrec_map : (A -> C -> prop) -> (B -> D -> prop) ->
+	         bindmutrec A B -> list C -> list D -> prop.
 bindmutrec_map P Q (bindmutrec BS) Ins Outs <-
   bindmany_map P (map Q) BS Ins Outs.
-bindmutrec_endmap : [A B C]
-		    (B -> C -> prop) ->
+bindmutrec_endmap : (B -> C -> prop) ->
 		    bindmutrec A B -> list C -> prop.
 bindmutrec_endmap P (bindmutrec BS) Out <-
   bindmany_endmap (map P) BS Out.
 
-bindmutrec_newvars : [A B] bindmutrec A B -> (list A -> prop) -> prop.
+bindmutrec_newvars : bindmutrec A B -> (list A -> prop) -> prop.
 bindmutrec_newvars (bindmutrec BS) P <- bindmany_newvars BS P.
 
-bindmutrec_apply   : [A B] bindmutrec A B -> list A -> list B -> prop.
+bindmutrec_apply   : bindmutrec A B -> list A -> list B -> prop.
 bindmutrec_apply (bindmutrec BS) XS ES <- bindmany_apply BS XS ES.
 
 
@@ -133,58 +129,56 @@ bindany : type -> type.
 bcons  : (A -> bindany T) -> bindany T.
 bnil   : T -> bindany T.
 
-bindany_cast     : T -> bindany A -> prop.
-bindany_cast_aux : T -> bindany A -> prop.
+bindany_cast     : {T} T -> bindany A -> prop.
+bindany_cast_aux : {T} T -> bindany A -> prop.
 
 bindany_cast X R <- once(bindany_cast_aux X R).
 bindany_cast_aux (fun (x : B) => P x) (bcons (fun (x : B) => R x)) <-
   (x:B -> once(bindany_cast_aux (P x) (R x))).
 bindany_cast_aux (X : A) ((bnil X) : bindany A).
 
-bindany_newvars : [A] bindany A -> (list dyn -> prop) -> prop.
-bindany_newvars_aux : [A] bindany A -> list dyn -> (list dyn -> prop) -> prop.
+bindany_newvars : bindany A -> (list dyn -> prop) -> prop.
+bindany_newvars_aux : bindany A -> list dyn -> (list dyn -> prop) -> prop.
 bindany_newvars_aux (bnil _)                     Vars P <- reverse Vars Vars', P Vars'.
 bindany_newvars_aux (bcons (F : T -> bindany A)) Vars P <-
   (x:T -> bindany_newvars_aux (F x) (cons (dyn x) Vars) P).
 bindany_newvars X P <- bindany_newvars_aux X nil P.
 
-bindany_apply : [A] bindany A -> list dyn -> A -> prop.
+bindany_apply : bindany A -> list dyn -> A -> prop.
 bindany_apply (bnil Body) (nil) Body.
 bindany_apply (bcons (F : T -> bindany A)) (cons (dyn (X : T)) XS) Body <-
   bindany_apply (F X) XS Body.
 
-bindany_apply_sametype : [A B] bindany A -> list B -> A -> prop.
+bindany_apply_sametype : bindany A -> list B -> A -> prop.
 bindany_apply_sametype (bnil Body) (nil) Body.
 bindany_apply_sametype (bcons F) (cons X XS) Body <-
   bindany_apply_sametype (F X) XS Body.
 
-bindany_apply_partial : [A] bindany A -> list dyn -> bindany A -> prop.
+bindany_apply_partial : bindany A -> list dyn -> bindany A -> prop.
 bindany_apply_partial End nil End.
 bindany_apply_partial (bcons (fun (x : T) => F x)) (cons (dyn (X : T)) XS) End <-
   bindany_apply_partial (F X) XS End.
 
-bindany_apply_partial_sametype : [A B] bindany A -> list B -> bindany A -> prop.
+bindany_apply_partial_sametype : bindany A -> list B -> bindany A -> prop.
 bindany_apply_partial_sametype End nil End.
 bindany_apply_partial_sametype (bcons F) (cons X XS) End <-
   bindany_apply_partial_sametype (F X) XS End.
 
-bindany_endmap : [B C]
-		  (B -> C -> prop) ->
-		  bindany B -> C -> prop.
+bindany_endmap : (B -> C -> prop) ->
+		 bindany B -> C -> prop.
 bindany_endmap P (bnil X) X' <- P X X'.
 bindany_endmap P (bcons (F : A -> bindany B)) X' <-
   (x:A -> bindany_endmap P (F x) X').
 
-bindany_modifybody : [B C]
-		     (B -> C -> prop) ->
+bindany_modifybody : (B -> C -> prop) ->
 		     bindany B -> bindany C -> prop.
 bindany_modifybody P (bnil X) (bnil X') <- P X X'.
 bindany_modifybody P (bcons (F : A -> bindany B)) (bcons (G : A -> bindany C)) <-
   (x:A -> bindany_modifybody P (F x) (G x)).
 
 (* TODO: fix this *)
-bindany_list_flatten : [A] list (bindany A) -> bindany (list A) -> prop.
-bindany_list_flatten_aux : [A] list (bindany A) -> bindany (list A) -> list A -> prop.
+bindany_list_flatten : list (bindany A) -> bindany (list A) -> prop.
+bindany_list_flatten_aux : list (bindany A) -> bindany (list A) -> list A -> prop.
 bindany_list_flatten_aux nil          (bnil Rev) Acc <- reverse Acc Rev.
 bindany_list_flatten_aux (cons HD TL) BHDRest Acc <-
   bindany_newvars HD (fun xs =>
@@ -205,27 +199,27 @@ listbindmany : type -> type -> type -> type.
 lbcons   : A -> (B -> listbindmany A B C) -> listbindmany A B C.
 lbnil    : C -> listbindmany A B C.
 
-listbindmany_binding : [A B C] listbindmany A B C -> bindmany B C -> prop.
+listbindmany_binding : listbindmany A B C -> bindmany B C -> prop.
 
 listbindmany_binding (lbnil C) (bnil C).
 listbindmany_binding (lbcons _ (F : B -> listbindmany A B C)) (bcons F') <-
   (x:B -> listbindmany_binding (F x) (F' x)).
 
-listbindmany_newvars : [A B C] listbindmany A B C -> (list B -> prop) -> prop.
+listbindmany_newvars : listbindmany A B C -> (list B -> prop) -> prop.
 listbindmany_newvars LB XSF <- listbindmany_binding LB B,
                                bindmany_newvars B XSF.
 
-listbindmany_apply : [A B C] listbindmany A B C -> list B -> C -> prop.
+listbindmany_apply : listbindmany A B C -> list B -> C -> prop.
 listbindmany_apply LB XS Body <- listbindmany_binding LB B,
                                  bindmany_apply B XS Body.
 
-listbindmany_getinfo : [A B C] listbindmany A B C -> list B -> list A -> prop.
+listbindmany_getinfo : listbindmany A B C -> list B -> list A -> prop.
 listbindmany_getinfo (lbnil Body) nil nil.
 listbindmany_getinfo (lbcons HD F) (cons X XS) (cons HD TL) <-
   listbindmany_getinfo (F X) XS TL.
 
-listbindmany_append : [A B C D] listbindmany A B C -> listbindmany A B D ->
-                                listbindmany A B D -> prop.
+listbindmany_append : listbindmany A B C -> listbindmany A B D ->
+                      listbindmany A B D -> prop.
 listbindmany_append (lbnil _) Rest Rest.
 listbindmany_append (lbcons HD (TL : B -> listbindmany A B C)) Rest (lbcons HD TL') <-
   (x:B -> listbindmany_append (TL x) Rest (TL' x)).
@@ -240,8 +234,7 @@ listbindany : type -> type.
 lbcons   : A -> bindany (listbindany A) -> listbindany A.
 lbnil    : listbindany A.
 
-listbindany_append : [A]
-		     listbindany A -> bindany (listbindany A) -> listbindany A -> prop.
+listbindany_append : listbindany A -> bindany (listbindany A) -> listbindany A -> prop.
 listbindany_append lbnil (bnil Y) Y.
 listbindany_append (lbcons HD BTL) BY (lbcons HD BR) <-
   bindany_newvars       BTL (fun vars =>

--- a/examples/lib/envlift.makam
+++ b/examples/lib/envlift.makam
@@ -3,7 +3,7 @@
 %use lmcomp.
 
 ctx         : type -> type.
-ctx_lookup  : [A] ctx A -> string -> A -> prop.
+ctx_lookup  : ctx A -> string -> A -> prop.
 ctx_guess   : string -> A -> ctx A -> prop.
 
 inenv : type -> type.

--- a/examples/lib/extutils.makam
+++ b/examples/lib/extutils.makam
@@ -1,12 +1,12 @@
 %use generic.
 
-find_benign : [A]A -> list A -> prop.
+find_benign : A -> list A -> prop.
 find_benign Elm (HD :: TL) <-
   ifte (eq_benign Elm HD)
        (success)
        (find_benign Elm TL).
 
-unique : [A]list A -> list A -> prop.
+unique : list A -> list A -> prop.
 unique Input Output <-
  foldl (fun cur elm res =>
         ifte (find_benign elm cur)
@@ -57,7 +57,7 @@ absunif Root (Unif : A) Res <-
 
 
 (* gather_all_unifs *)
-gather_all_unifs : [A] dyn -> A -> list A -> prop.
+gather_all_unifs : dyn -> A -> list A -> prop.
 
 gather_all_unifs_aux : A -> dyn -> list A -> list A -> prop.
 

--- a/examples/lib/generic.makam
+++ b/examples/lib/generic.makam
@@ -54,7 +54,7 @@ eq_benign X Y <- eq_benign_aux (dyn X) (dyn Y).
 (eq_benign_aux (dyn (X : A -> B)) (dyn (Y : A -> B))) when not(refl.isunif X), not(refl.isunif Y) <-
   (x:A -> eq_benign_aux (dyn (X x)) (dyn (Y x))).
 
-builtintyp : {A} A -> prop.
+builtintyp : [A] A -> prop.
 builtintyp (X : A -> B).
 builtintyp (X : string).
 builtintyp (X : int).

--- a/examples/lib/generic.makam
+++ b/examples/lib/generic.makam
@@ -42,7 +42,7 @@ when not(typeq X (B : C -> D)), not(refl.isunif X) <-
 
 
 (* eq_benign: no instantiation goes on. *)
-eq_benign : [A]A -> A -> prop.
+eq_benign : A -> A -> prop.
 eq_benign_aux : dyn -> dyn -> prop.
 
 eq_benign X Y <- eq_benign_aux (dyn X) (dyn Y).
@@ -54,7 +54,7 @@ eq_benign X Y <- eq_benign_aux (dyn X) (dyn Y).
 (eq_benign_aux (dyn (X : A -> B)) (dyn (Y : A -> B))) when not(refl.isunif X), not(refl.isunif Y) <-
   (x:A -> eq_benign_aux (dyn (X x)) (dyn (Y x))).
 
-builtintyp : A -> prop.
+builtintyp : {A} A -> prop.
 builtintyp (X : A -> B).
 builtintyp (X : string).
 builtintyp (X : int).

--- a/examples/lib/lmcomp.makam
+++ b/examples/lib/lmcomp.makam
@@ -9,8 +9,8 @@ lm_pattbody : type -> type -> type.
 
 lm_fun      : (A -> lm_comp B) -> lm_arrow A B.
 
-lm_forward  : [A B] lm_arrow A B -> (A -> B -> prop) -> prop.
-lm_backward : [A B] lm_arrow A B -> (B -> A -> prop) -> prop.
+lm_forward  : lm_arrow A B -> (A -> B -> prop) -> prop.
+lm_backward : lm_arrow A B -> (B -> A -> prop) -> prop.
 
 lm_lift     : (A -> B -> prop) -> A -> lm_comp B.
 lm_liftback : (A -> B -> prop) -> B -> lm_comp A.
@@ -35,7 +35,7 @@ lm_recdef       : lm_recarrow A B -> lm_arrow A B -> prop.
 
 lm_to_ipred         : lm_arrow A B -> (A -> B -> ipred) -> prop.
 lmcomp_to_ipred     : lm_comp B -> (B -> ipred) -> prop.
-lmpattbody_to_ipred : [A B] lm_pattbody A B -> lm_comp B -> (A -> B -> ipred) -> prop.
+lmpattbody_to_ipred : lm_pattbody A B -> lm_comp B -> (A -> B -> ipred) -> prop.
 
 lm_to_ipred (lm_fun (Comp : A -> lm_comp B)) IPred <-
   (input:A -> lmcomp_to_ipred (Comp inputⁿ_) (IPred inputⁿ_)).
@@ -64,12 +64,12 @@ lmpattbody_to_ipred (lm_patt_end Patt Body) Otherwise
   lmcomp_to_ipred Body Body',
   lmcomp_to_ipred Otherwise Otherwise'.
 
-lm_forward : [A B] lm_arrow A B -> (A -> B -> prop) -> prop.
+lm_forward : lm_arrow A B -> (A -> B -> prop) -> prop.
 lm_forward (Comp : lm_arrow A B) (P : A -> B -> prop) <-
   lm_to_ipred Comp IP,
   (input:A -> (output:B -> ipred_forward (IP inputⁿ_ outputⁿ_) (P inputⁿ_ outputⁿ_))).
 
-lm_backward : [A B] lm_arrow A B -> (B -> A -> prop) -> prop.
+lm_backward : lm_arrow A B -> (B -> A -> prop) -> prop.
 lm_backward Comp (P : B -> A -> prop) <-
   lm_to_ipred Comp IP,
   (input:A -> (output:B -> ipred_backward (IP inputⁿ_ outputⁿ_) (P outputⁿ_ inputⁿ_))).

--- a/examples/lib/utils.makam
+++ b/examples/lib/utils.makam
@@ -6,67 +6,67 @@ eq X X.
 not : prop -> prop.
 not P <- if once P then failure else success.
 
-is : [A] A -> (A -> prop) -> prop.
+is : A -> (A -> prop) -> prop.
 is X F <- F X.
 
 
 (* list stuff *)
-map0 : [A] (A -> prop) -> list A -> prop.
+map0 : (A -> prop) -> list A -> prop.
 map0 P nil.
 map0 P (cons HD TL) <- P HD, map0 P TL.
 
-map : [A B] (A -> B -> prop) -> list A -> list B -> prop.
+map : (A -> B -> prop) -> list A -> list B -> prop.
 map P nil nil.
 map P (cons HD TL) (cons HD' TL') <- P HD HD', map P TL TL'.
 
-map2 : [A B C] (A -> B -> C -> prop) -> list A -> list B -> list C -> prop.
+map2 : (A -> B -> C -> prop) -> list A -> list B -> list C -> prop.
 map2 P nil nil nil.
 map2 P (cons HD TL) (cons HD' TL') (cons HD'' TL'') <- P HD HD' HD'', map2 P TL TL' TL''.
 
-map3 : [A B C D] (A -> B -> C -> D -> prop) -> list A -> list B -> list C -> list D -> prop.
+map3 : (A -> B -> C -> D -> prop) -> list A -> list B -> list C -> list D -> prop.
 map3 P nil nil nil nil.
 map3 P (cons HDA TLA) (cons HDB TLB) (cons HDC TLC) (cons HDD TLD) <- P HDA HDB HDC HDD, map3 P TLA TLB TLC TLD.
 
-snoc : [A] list A -> A -> list A -> prop.
+snoc : list A -> A -> list A -> prop.
 snoc nil Last (cons Last nil).
 snoc (cons Hd Tl) Last (cons Hd Tl') <- snoc Tl Last Tl'.
 
-foldr : [A B] (A -> B -> B -> prop) -> list A -> B -> B -> prop.
+foldr : (A -> B -> B -> prop) -> list A -> B -> B -> prop.
 foldr P nil S S.
 foldr P (cons HD TL) S S'' <- foldr P TL S S', P HD S' S''.
 
-foldrinv : [A B] (A -> B -> B -> prop) -> B -> list A -> B -> prop.
+foldrinv : (A -> B -> B -> prop) -> B -> list A -> B -> prop.
 foldrinv P SStart Res SEnd <-
   if P Hd SNext SStart
   then (foldrinv P SNext Tl SEnd, eq Res (cons Hd Tl))
   else (eq Res nil, eq SStart SEnd).
 
 
-foldl : [A B] (B -> A -> B -> prop) -> B -> list A -> B -> prop.
+foldl : (B -> A -> B -> prop) -> B -> list A -> B -> prop.
 foldl P S nil S.
 foldl P S (cons HD TL) S'' <- P S HD S', foldl P S' TL S''.
 
-find : [A] list A -> A -> prop.
+find : list A -> A -> prop.
 find (HD :: TL) HD.
 find (HD' :: TL) HD <- find TL HD.
 
-foldlinv : [A B] (B -> A -> B -> prop) -> B -> list A -> B -> prop.
+foldlinv : (B -> A -> B -> prop) -> B -> list A -> B -> prop.
 foldlinv P SEnd Res SStart <-
   if P SPrev Last SEnd
   then (foldlinv P SPrev Res' SStart, snoc Res' Last Res)
   else (eq Res nil, eq SStart SEnd).
 
-reverse : [A] list A -> list A -> prop.
-reverse_aux : [A] list A -> (list A -> list A) -> list A -> prop.
+reverse : list A -> list A -> prop.
+reverse_aux : list A -> (list A -> list A) -> list A -> prop.
 reverse_aux nil L (L nil).
 reverse_aux (cons HD TL) L L' <- reverse_aux TL (fun x => cons HD (L x)) L'.
 reverse L L' <- reverse_aux L (fun x => x) L'.
 
-append : [A] list A -> list A -> list A -> prop.
+append : list A -> list A -> list A -> prop.
 append nil Y Y.
 append (cons HD TL) Y (cons HD TL') <- append TL Y TL'.
 
-flatten : [A] list (list A) -> list A -> prop.
+flatten : list (list A) -> list A -> prop.
 flatten LS L <- foldl (fun cur elm res => newmeta (fun rev => and (reverse elm rev) (append rev cur res))) nil LS Lrev, reverse Lrev L.
 
 
@@ -77,14 +77,14 @@ option : type -> type.
 none : option A.
 some : A -> option A.
 
-map : [A B C D] (A -> C -> prop) -> (B -> D -> prop) -> tuple A B -> tuple C D -> prop.
+map : (A -> C -> prop) -> (B -> D -> prop) -> tuple A B -> tuple C D -> prop.
 map P Q (tuple X Y) (tuple X' Y') <- P X X', Q Y Y'.
 
-split : [A B] (list (tuple A B)) -> tuple (list A) (list B) -> prop.
+split : (list (tuple A B)) -> tuple (list A) (list B) -> prop.
 split nil (tuple nil nil).
 split (cons (tuple HD1 HD2) TL) (tuple (cons HD1 TL1) (cons HD2 TL2)) <- split TL (tuple TL1 TL2).
 
-filterlist : [A] list (option A) -> list A -> prop.
+filterlist : list (option A) -> list A -> prop.
 filterlist nil nil.
 filterlist (cons (some HD) TL) (cons HD TL') <- filterlist TL TL'.
 filterlist (cons none TL) TL' <- filterlist TL TL'.
@@ -98,7 +98,7 @@ is_constructor X <- newfmeta (fun c => eq c X).
 renamebinder : (A -> B) -> string -> (A -> B) -> prop.
 renamebinder F ID (fun newbinderⁿID => F newbinderⁿID).
 
-printhead : A -> prop.
+printhead : {A} A -> prop.
 printhead (X : A -> B) <- (x:A -> printhead (X x)).
 (printhead (X : A)) when not(eq (dyn(X : A)) (dyn(Y : B -> C))) <- refl.headargs X HD _, refl.headname HD S, print S.
 
@@ -111,15 +111,15 @@ assumemanyclauses : list clause -> prop -> prop.
 assumemanyclauses (cons HD TL) P <- assume HD (assumemanyclauses TL P).
 assumemanyclauses nil P <- P.
 
-define : [A] (A -> prop) -> (A -> prop) -> cmd -> prop.
+define : (A -> prop) -> (A -> prop) -> cmd -> prop.
 define Pred How (cmd_newclause (clause (Pred Res) success)) <- How Res.
 
 
-case : [A] A -> (list (tuple A prop)) -> prop.
+case : A -> (list (tuple A prop)) -> prop.
 case Scrutinee ( (Pattern, Body) :: Rest ) <-
   if eq Scrutinee Pattern then Body else case Scrutinee Rest.
 
-caseguard : [A] A -> (list (tuple A (tuple prop prop))) -> prop.
+caseguard : A -> (list (tuple A (tuple prop prop))) -> prop.
 caseguard Scrutinee ( (Pattern, Guard, Body) :: Rest ) <-
   if (eq Scrutinee Pattern, Guard) then Body else caseguard Scrutinee Rest.
 
@@ -131,29 +131,29 @@ isdeepunif A <-
           [ (dyn (dyn X), isdeepunif X),
             (dyn (tuple X Y), {prop| isdeepunif X, isdeepunif Y |}) ].
 
-defcase : [A] A -> prop -> (list (tuple A prop)) -> prop.
+defcase : A -> prop -> (list (tuple A prop)) -> prop.
 defcase Scrutinee Default Branches <-
   if isdeepunif Scrutinee then Default
   else ((case Scrutinee nil <- Default) ->
          case Scrutinee Branches ).
 
 (* dynamic types *)
-dyneq : A -> B -> prop.
+dyneq : {B} A -> B -> prop.
 dyneq X X.
 
 dynmap : (dyn -> dyn -> prop) -> list dyn -> list dyn -> prop.
 dynmap P nil nil.
 dynmap P (cons (dyn HD) TL) (cons (dyn HD') TL') <- P (dyn HD) (dyn HD'), dynmap P TL TL'.
 
-applymany : A -> list dyn -> B -> prop.
+applymany : {A B} A -> list dyn -> B -> prop.
 applymany X ( ( dyn (HD : A) ) :: TL ) RES <-
   applymany (X HD) TL RES.
 applymany X [] X.
 
-typeq : A -> B -> prop.
+typeq : {B} A -> B -> prop.
 typeq (X : A) (Y : A).
 
-appmany : A -> list dyn -> B -> prop.
+appmany : {A B} A -> list dyn -> B -> prop.
 appmany (X : A) nil (X : A).
 appmany (X : A -> B) (cons (dyn (HD : A)) TL) Res <- appmany (X HD) TL Res.
 
@@ -163,7 +163,7 @@ newvmeta P <- if newfmeta P then success else newnmeta P.
 isnvar : A -> prop.
 (isnvar X) when newnmeta (fun x => eq x X).
 
-userdef_headargs : A -> B -> list dyn -> prop.
+userdef_headargs : {A B} A -> B -> list dyn -> prop.
 userdef_headargs (X : A) C List <- newvmeta (fun (Y : A) => {prop|
                             eq X Y, eq C Y, eq List [] |}).
 userdef_headargs (X : A) C List <- newvmeta (fun (Y : A1 -> A) => {prop|

--- a/examples/lib/utils.makam
+++ b/examples/lib/utils.makam
@@ -98,7 +98,7 @@ is_constructor X <- newfmeta (fun c => eq c X).
 renamebinder : (A -> B) -> string -> (A -> B) -> prop.
 renamebinder F ID (fun newbinderⁿID => F newbinderⁿID).
 
-printhead : {A} A -> prop.
+printhead : [A] A -> prop.
 printhead (X : A -> B) <- (x:A -> printhead (X x)).
 (printhead (X : A)) when not(eq (dyn(X : A)) (dyn(Y : B -> C))) <- refl.headargs X HD _, refl.headname HD S, print S.
 
@@ -138,22 +138,22 @@ defcase Scrutinee Default Branches <-
          case Scrutinee Branches ).
 
 (* dynamic types *)
-dyneq : {B} A -> B -> prop.
+dyneq : [B] A -> B -> prop.
 dyneq X X.
 
 dynmap : (dyn -> dyn -> prop) -> list dyn -> list dyn -> prop.
 dynmap P nil nil.
 dynmap P (cons (dyn HD) TL) (cons (dyn HD') TL') <- P (dyn HD) (dyn HD'), dynmap P TL TL'.
 
-applymany : {A B} A -> list dyn -> B -> prop.
+applymany : [A B] A -> list dyn -> B -> prop.
 applymany X ( ( dyn (HD : A) ) :: TL ) RES <-
   applymany (X HD) TL RES.
 applymany X [] X.
 
-typeq : {B} A -> B -> prop.
+typeq : [B] A -> B -> prop.
 typeq (X : A) (Y : A).
 
-appmany : {A B} A -> list dyn -> B -> prop.
+appmany : [A B] A -> list dyn -> B -> prop.
 appmany (X : A) nil (X : A).
 appmany (X : A -> B) (cons (dyn (HD : A)) TL) Res <- appmany (X HD) TL Res.
 
@@ -163,7 +163,7 @@ newvmeta P <- if newfmeta P then success else newnmeta P.
 isnvar : A -> prop.
 (isnvar X) when newnmeta (fun x => eq x X).
 
-userdef_headargs : {A B} A -> B -> list dyn -> prop.
+userdef_headargs : [A B] A -> B -> list dyn -> prop.
 userdef_headargs (X : A) C List <- newvmeta (fun (Y : A) => {prop|
                             eq X Y, eq C Y, eq List [] |}).
 userdef_headargs (X : A) C List <- newvmeta (fun (Y : A1 -> A) => {prop|

--- a/examples/new/ocaml.makam
+++ b/examples/new/ocaml.makam
@@ -219,7 +219,7 @@ typeof (projrec E Field) T <-
   typapply TC TS T,
   once (typeof E (tbase Tbase TS)).
 
-guess_type : [A] map string A -> string -> prop.
+guess_type : map string A -> string -> prop.
 guess_type Map Tbase <-
   map.headtail Map (Key, _) _,
   field_def Key _ Tbase.

--- a/examples/new/ocamlpretty.makam
+++ b/examples/new/ocamlpretty.makam
@@ -6,9 +6,9 @@ concat SS S <- foldr string.append SS "" S.
 %end.
 
 
-gracewithnames : {A} A -> A -> prop.
-gracewithnames : {A} int -> A -> A -> prop.
-gracewithnames_ : {A} int -> A -> A -> prop.
+gracewithnames : [A] A -> A -> prop.
+gracewithnames : [A] int -> A -> A -> prop.
+gracewithnames_ : [A] int -> A -> A -> prop.
 
 gracewithnames X Y <-
   gracewithnames 0 X Y.

--- a/examples/new/ocamlpretty.makam
+++ b/examples/new/ocamlpretty.makam
@@ -6,9 +6,9 @@ concat SS S <- foldr string.append SS "" S.
 %end.
 
 
-gracewithnames : A -> A -> prop.
-gracewithnames : int -> A -> A -> prop.
-gracewithnames_ : int -> A -> A -> prop.
+gracewithnames : {A} A -> A -> prop.
+gracewithnames : {A} int -> A -> A -> prop.
+gracewithnames_ : {A} int -> A -> A -> prop.
 
 gracewithnames X Y <-
   gracewithnames 0 X Y.
@@ -22,7 +22,7 @@ gracewithnames_ N (X : bindone typ A) Y when bindone.varname X S, refl.isunif S 
   bindone.open X Y (fun x body body' => gracewithnames N' body body').
 
 
-listdo : [A]list (A -> prop) -> list A -> prop.
+listdo : list (A -> prop) -> list A -> prop.
 listdo L L' <- map (fun p => p) L L'.
 
 doconcat : list (string -> prop) -> string -> prop.

--- a/examples/new/testcases_ocaml.makam
+++ b/examples/new/testcases_ocaml.makam
@@ -1,10 +1,9 @@
 %use ocaml.
 %use ocamlpretty.
 
-ocaml_test_suite : test_suite.
+ocaml_test_suite : testsuite.
 
 testcase ocaml_test_suite <-
-  failure,
   typeof (let (lam (bindone "x" (fun x => x))) (bindone "id" (fun id => id))) X,
   gracewithnames X X',
   eq_nounif X' (tpi ktype (bindone "a0" (fun a => tarrow a a))).

--- a/examples/paper/03-dependent-binding.makam
+++ b/examples/paper/03-dependent-binding.makam
@@ -36,13 +36,13 @@ follows:
 
 *)
 
-vmap : {N} (A -> B -> prop) -> vector N A -> vector N B -> prop.
+vmap : [N] (A -> B -> prop) -> vector N A -> vector N B -> prop.
 vmap P vnil vnil.
 vmap P (vcons X XS) (vcons Y YS) :- P X Y, vmap P XS YS.
 
 (*
 
-The notation `{N}` in the type of `vmap` means that the type argument `N` is ad-hoc/not-parametric.
+The notation `[N]` in the type of `vmap` means that the type argument `N` is ad-hoc/not-parametric.
 Non-specified type arguments are parametric by default, so as to match standard practice in
 languages like ML and Haskell, and to catch type errors that allowing unqualified ad-hoc
 polymorphism would permit. For example, consider the following erroneous definition for `fold`,
@@ -107,9 +107,9 @@ The predicates are now defined as follows. First, their types are:
 
 *)
 
-intromany : {T} dbind A T B -> (subst A T -> prop) -> prop.
-applymany : {T} dbind A T B -> subst A T -> B -> prop.
-openmany : {T} dbind A T B -> (subst A T -> B -> prop) -> prop.
+intromany : [T] dbind A T B -> (subst A T -> prop) -> prop.
+applymany : [T] dbind A T B -> subst A T -> B -> prop.
+openmany : [T] dbind A T B -> (subst A T -> B -> prop) -> prop.
 
 (*
 
@@ -140,11 +140,11 @@ Also, we define predicates analogous to `map` and `assumemany` for the
 
 *)
 
-assumemany : {T T'} (A -> B -> prop) -> subst A T -> subst B T' -> prop -> prop.
+assumemany : [T T'] (A -> B -> prop) -> subst A T -> subst B T' -> prop -> prop.
 assumemany P snil snil Q :- Q.
 assumemany P (scons X XS) (scons Y YS) Q :- (P X Y -> assumemany P XS YS Q).
 
-map : {T T'} (A -> B -> prop) -> subst A T -> subst B T' -> prop.
+map : [T T'] (A -> B -> prop) -> subst A T -> subst B T' -> prop.
 map P snil snil.
 map P (scons X XS) (scons Y YS) :- P X Y, map P XS YS.
 
@@ -279,7 +279,7 @@ available, plus the type of the pattern.
 
 *)
 
-typeof : {T T' Ttyp T'typ} patt T T' -> subst typ T'typ -> subst typ Ttyp -> typ -> prop.
+typeof : [T T' Ttyp T'typ] patt T T' -> subst typ T'typ -> subst typ Ttyp -> typ -> prop.
 
 typeof patt_var S' (scons T S') T.
 typeof patt_wild S S T.
@@ -288,7 +288,7 @@ typeof (patt_succ P) S' S nat :-
   typeof P S' S nat.
 
 typeof_pattlist :
-  {T T' Ttyp T'typ} pattlist T T' -> subst typ T'typ -> subst typ Ttyp -> list typ -> prop.
+  [T T' Ttyp T'typ] pattlist T T' -> subst typ T'typ -> subst typ Ttyp -> list typ -> prop.
 
 typeof (patt_tuple PS) S' S (product TS) :-
   typeof_pattlist PS S' S TS.
@@ -316,13 +316,13 @@ unification with the scrutinee succeeds.
 
 *)
 
-patt_to_term : {T T'} patt T T' -> term -> subst term T' -> subst term T -> prop.
+patt_to_term : [T T'] patt T T' -> term -> subst term T' -> subst term T -> prop.
 patt_to_term patt_var X Subst (scons X Subst).
 patt_to_term patt_wild _ Subst Subst.
 patt_to_term patt_zero zero Subst Subst.
 patt_to_term (patt_succ PN) (succ EN) Subst' Subst :- patt_to_term PN EN Subst' Subst.
 
-pattlist_to_termlist : {T T'} pattlist T T' -> list term -> subst term T' -> subst term T -> prop.
+pattlist_to_termlist : [T T'] pattlist T T' -> list term -> subst term T' -> subst term T -> prop.
 
 patt_to_term (patt_tuple PS) (tuple ES) Subst' Subst :-
   pattlist_to_termlist PS ES Subst' Subst.

--- a/examples/paper/03-dependent-binding.makam
+++ b/examples/paper/03-dependent-binding.makam
@@ -36,13 +36,13 @@ follows:
 
 *)
 
-vmap : [A B] (A -> B -> prop) -> vector N A -> vector N B -> prop.
+vmap : {N} (A -> B -> prop) -> vector N A -> vector N B -> prop.
 vmap P vnil vnil.
 vmap P (vcons X XS) (vcons Y YS) :- P X Y, vmap P XS YS.
 
 (*
 
-The notation `[N]` in the type of `vmap` means that the type argument `N` is ad-hoc/not-parametric.
+The notation `{N}` in the type of `vmap` means that the type argument `N` is ad-hoc/not-parametric.
 Non-specified type arguments are parametric by default, so as to match standard practice in
 languages like ML and Haskell, and to catch type errors that allowing unqualified ad-hoc
 polymorphism would permit. For example, consider the following erroneous definition for `fold`,
@@ -107,9 +107,9 @@ The predicates are now defined as follows. First, their types are:
 
 *)
 
-intromany : [A B] dbind A T B -> (subst A T -> prop) -> prop.
-applymany : [A B] dbind A T B -> subst A T -> B -> prop.
-openmany : [A B] dbind A T B -> (subst A T -> B -> prop) -> prop.
+intromany : {T} dbind A T B -> (subst A T -> prop) -> prop.
+applymany : {T} dbind A T B -> subst A T -> B -> prop.
+openmany : {T} dbind A T B -> (subst A T -> B -> prop) -> prop.
 
 (*
 
@@ -140,11 +140,11 @@ Also, we define predicates analogous to `map` and `assumemany` for the
 
 *)
 
-assumemany : (A -> B -> prop) -> subst A T -> subst B T' -> prop -> prop.
+assumemany : {T T'} (A -> B -> prop) -> subst A T -> subst B T' -> prop -> prop.
 assumemany P snil snil Q :- Q.
 assumemany P (scons X XS) (scons Y YS) Q :- (P X Y -> assumemany P XS YS Q).
 
-map : [A B] (A -> B -> prop) -> subst A T -> subst B T' -> prop.
+map : {T T'} (A -> B -> prop) -> subst A T -> subst B T' -> prop.
 map P snil snil.
 map P (scons X XS) (scons Y YS) :- P X Y, map P XS YS.
 
@@ -279,7 +279,7 @@ available, plus the type of the pattern.
 
 *)
 
-typeof : patt T T' -> subst typ T'typ -> subst typ Ttyp -> typ -> prop.
+typeof : {T T' Ttyp T'typ} patt T T' -> subst typ T'typ -> subst typ Ttyp -> typ -> prop.
 
 typeof patt_var S' (scons T S') T.
 typeof patt_wild S S T.
@@ -287,7 +287,8 @@ typeof patt_zero S S nat.
 typeof (patt_succ P) S' S nat :-
   typeof P S' S nat.
 
-typeof_pattlist : pattlist T T' -> subst typ T'typ -> subst typ Ttyp -> list typ -> prop.
+typeof_pattlist :
+  {T T' Ttyp T'typ} pattlist T T' -> subst typ T'typ -> subst typ Ttyp -> list typ -> prop.
 
 typeof (patt_tuple PS) S' S (product TS) :-
   typeof_pattlist PS S' S TS.
@@ -315,13 +316,13 @@ unification with the scrutinee succeeds.
 
 *)
 
-patt_to_term : patt T T' -> term -> subst term T' -> subst term T -> prop.
+patt_to_term : {T T'} patt T T' -> term -> subst term T' -> subst term T -> prop.
 patt_to_term patt_var X Subst (scons X Subst).
 patt_to_term patt_wild _ Subst Subst.
 patt_to_term patt_zero zero Subst Subst.
 patt_to_term (patt_succ PN) (succ EN) Subst' Subst :- patt_to_term PN EN Subst' Subst.
 
-pattlist_to_termlist : pattlist T T' -> list term -> subst term T' -> subst term T -> prop.
+pattlist_to_termlist : {T T'} pattlist T T' -> list term -> subst term T' -> subst term T -> prop.
 
 patt_to_term (patt_tuple PS) (tuple ES) Subst' Subst :-
   pattlist_to_termlist PS ES Subst' Subst.
@@ -344,7 +345,7 @@ Two new things here: if-then-else has the semantics described in the LogicT mona
 
 *)
 
-eq : [A] A -> A -> prop.
+eq : A -> A -> prop.
 eq X X.
 
 (*

--- a/examples/paper/03-dependent-binding.md
+++ b/examples/paper/03-dependent-binding.md
@@ -30,12 +30,12 @@ distinguish between different types. Based on these, the standard example of `ma
 follows:
 
 ```makam
-vmap : [A B] (A -> B -> prop) -> vector N A -> vector N B -> prop.
+vmap : {N} (A -> B -> prop) -> vector N A -> vector N B -> prop.
 vmap P vnil vnil.
 vmap P (vcons X XS) (vcons Y YS) :- P X Y, vmap P XS YS.
 ```
 
-The notation `[N]` in the type of `vmap` means that the type argument `N` is ad-hoc/not-parametric.
+The notation `{N}` in the type of `vmap` means that the type argument `N` is ad-hoc/not-parametric.
 Non-specified type arguments are parametric by default, so as to match standard practice in
 languages like ML and Haskell, and to catch type errors that allowing unqualified ad-hoc
 polymorphism would permit. For example, consider the following erroneous definition for `fold`,
@@ -93,9 +93,9 @@ scons : A -> subst A T -> subst A (A * T).
 The predicates are now defined as follows. First, their types are: 
 
 ```makam
-intromany : [A B] dbind A T B -> (subst A T -> prop) -> prop.
-applymany : [A B] dbind A T B -> subst A T -> B -> prop.
-openmany : [A B] dbind A T B -> (subst A T -> B -> prop) -> prop.
+intromany : {T} dbind A T B -> (subst A T -> prop) -> prop.
+applymany : {T} dbind A T B -> subst A T -> B -> prop.
+openmany : {T} dbind A T B -> (subst A T -> B -> prop) -> prop.
 ```
 
 Note that we are reusing the same predicate names as before. Makam allows overloading for all
@@ -122,11 +122,11 @@ Also, we define predicates analogous to `map` and `assumemany` for the
 `subst` type: 
 
 ```makam
-assumemany : (A -> B -> prop) -> subst A T -> subst B T' -> prop -> prop.
+assumemany : {T T'} (A -> B -> prop) -> subst A T -> subst B T' -> prop -> prop.
 assumemany P snil snil Q :- Q.
 assumemany P (scons X XS) (scons Y YS) Q :- (P X Y -> assumemany P XS YS Q).
 
-map : [A B] (A -> B -> prop) -> subst A T -> subst B T' -> prop.
+map : {T T'} (A -> B -> prop) -> subst A T -> subst B T' -> prop.
 map P snil snil.
 map P (scons X XS) (scons Y YS) :- P X Y, map P XS YS.
 ```
@@ -241,7 +241,7 @@ variables that remain after the pattern, yield a list of types for all the varia
 available, plus the type of the pattern.
 
 ```makam
-typeof : patt T T' -> subst typ T'typ -> subst typ Ttyp -> typ -> prop.
+typeof : {T T' Ttyp T'typ} patt T T' -> subst typ T'typ -> subst typ Ttyp -> typ -> prop.
 
 typeof patt_var S' (scons T S') T.
 typeof patt_wild S S T.
@@ -249,7 +249,8 @@ typeof patt_zero S S nat.
 typeof (patt_succ P) S' S nat :-
   typeof P S' S nat.
 
-typeof_pattlist : pattlist T T' -> subst typ T'typ -> subst typ Ttyp -> list typ -> prop.
+typeof_pattlist :
+  {T T' Ttyp T'typ} pattlist T T' -> subst typ T'typ -> subst typ Ttyp -> list typ -> prop.
 
 typeof (patt_tuple PS) S' S (product TS) :-
   typeof_pattlist PS S' S TS.
@@ -275,13 +276,13 @@ introduced at each conversion rule as needed, and will get instantiated to the r
 unification with the scrutinee succeeds.
 
 ```makam
-patt_to_term : patt T T' -> term -> subst term T' -> subst term T -> prop.
+patt_to_term : {T T'} patt T T' -> term -> subst term T' -> subst term T -> prop.
 patt_to_term patt_var X Subst (scons X Subst).
 patt_to_term patt_wild _ Subst Subst.
 patt_to_term patt_zero zero Subst Subst.
 patt_to_term (patt_succ PN) (succ EN) Subst' Subst :- patt_to_term PN EN Subst' Subst.
 
-pattlist_to_termlist : pattlist T T' -> list term -> subst term T' -> subst term T -> prop.
+pattlist_to_termlist : {T T'} pattlist T T' -> list term -> subst term T' -> subst term T -> prop.
 
 patt_to_term (patt_tuple PS) (tuple ES) Subst' Subst :-
   pattlist_to_termlist PS ES Subst' Subst.
@@ -302,7 +303,7 @@ Two new things here: if-then-else has the semantics described in the LogicT mona
 `eq` is a predicate that forces its arguments to be unified, defined simply as:
 
 ```makam
-eq : [A] A -> A -> prop.
+eq : A -> A -> prop.
 eq X X.
 ```
 

--- a/examples/paper/03-dependent-binding.md
+++ b/examples/paper/03-dependent-binding.md
@@ -30,12 +30,12 @@ distinguish between different types. Based on these, the standard example of `ma
 follows:
 
 ```makam
-vmap : {N} (A -> B -> prop) -> vector N A -> vector N B -> prop.
+vmap : [N] (A -> B -> prop) -> vector N A -> vector N B -> prop.
 vmap P vnil vnil.
 vmap P (vcons X XS) (vcons Y YS) :- P X Y, vmap P XS YS.
 ```
 
-The notation `{N}` in the type of `vmap` means that the type argument `N` is ad-hoc/not-parametric.
+The notation `[N]` in the type of `vmap` means that the type argument `N` is ad-hoc/not-parametric.
 Non-specified type arguments are parametric by default, so as to match standard practice in
 languages like ML and Haskell, and to catch type errors that allowing unqualified ad-hoc
 polymorphism would permit. For example, consider the following erroneous definition for `fold`,
@@ -93,9 +93,9 @@ scons : A -> subst A T -> subst A (A * T).
 The predicates are now defined as follows. First, their types are: 
 
 ```makam
-intromany : {T} dbind A T B -> (subst A T -> prop) -> prop.
-applymany : {T} dbind A T B -> subst A T -> B -> prop.
-openmany : {T} dbind A T B -> (subst A T -> B -> prop) -> prop.
+intromany : [T] dbind A T B -> (subst A T -> prop) -> prop.
+applymany : [T] dbind A T B -> subst A T -> B -> prop.
+openmany : [T] dbind A T B -> (subst A T -> B -> prop) -> prop.
 ```
 
 Note that we are reusing the same predicate names as before. Makam allows overloading for all
@@ -122,11 +122,11 @@ Also, we define predicates analogous to `map` and `assumemany` for the
 `subst` type: 
 
 ```makam
-assumemany : {T T'} (A -> B -> prop) -> subst A T -> subst B T' -> prop -> prop.
+assumemany : [T T'] (A -> B -> prop) -> subst A T -> subst B T' -> prop -> prop.
 assumemany P snil snil Q :- Q.
 assumemany P (scons X XS) (scons Y YS) Q :- (P X Y -> assumemany P XS YS Q).
 
-map : {T T'} (A -> B -> prop) -> subst A T -> subst B T' -> prop.
+map : [T T'] (A -> B -> prop) -> subst A T -> subst B T' -> prop.
 map P snil snil.
 map P (scons X XS) (scons Y YS) :- P X Y, map P XS YS.
 ```
@@ -241,7 +241,7 @@ variables that remain after the pattern, yield a list of types for all the varia
 available, plus the type of the pattern.
 
 ```makam
-typeof : {T T' Ttyp T'typ} patt T T' -> subst typ T'typ -> subst typ Ttyp -> typ -> prop.
+typeof : [T T' Ttyp T'typ] patt T T' -> subst typ T'typ -> subst typ Ttyp -> typ -> prop.
 
 typeof patt_var S' (scons T S') T.
 typeof patt_wild S S T.
@@ -250,7 +250,7 @@ typeof (patt_succ P) S' S nat :-
   typeof P S' S nat.
 
 typeof_pattlist :
-  {T T' Ttyp T'typ} pattlist T T' -> subst typ T'typ -> subst typ Ttyp -> list typ -> prop.
+  [T T' Ttyp T'typ] pattlist T T' -> subst typ T'typ -> subst typ Ttyp -> list typ -> prop.
 
 typeof (patt_tuple PS) S' S (product TS) :-
   typeof_pattlist PS S' S TS.
@@ -276,13 +276,13 @@ introduced at each conversion rule as needed, and will get instantiated to the r
 unification with the scrutinee succeeds.
 
 ```makam
-patt_to_term : {T T'} patt T T' -> term -> subst term T' -> subst term T -> prop.
+patt_to_term : [T T'] patt T T' -> term -> subst term T' -> subst term T -> prop.
 patt_to_term patt_var X Subst (scons X Subst).
 patt_to_term patt_wild _ Subst Subst.
 patt_to_term patt_zero zero Subst Subst.
 patt_to_term (patt_succ PN) (succ EN) Subst' Subst :- patt_to_term PN EN Subst' Subst.
 
-pattlist_to_termlist : {T T'} pattlist T T' -> list term -> subst term T' -> subst term T -> prop.
+pattlist_to_termlist : [T T'] pattlist T T' -> list term -> subst term T' -> subst term T -> prop.
 
 patt_to_term (patt_tuple PS) (tuple ES) Subst' Subst :-
   pattlist_to_termlist PS ES Subst' Subst.

--- a/examples/peg/dbt.makam
+++ b/examples/peg/dbt.makam
@@ -38,14 +38,14 @@ dbtrun (dbt_lam (F : A -> dbt)) (dyn E) <-
 dbtrun (dbt_int I) (dyn (I : int)).
 dbtrun (dbt_string S) (dyn (S : string)).
 
-dbtenv : string -> A -> prop.
+dbtenv : {A} string -> A -> prop.
 dbtmagicenv : list string -> prop.
 dbtmagic : list dyn -> A.
 
-findbenign : [A] list A -> A -> prop.
+findbenign : list A -> A -> prop.
 findbenign L HD <-
   (if refl.isunif L
-   then failure,
+   then failure
    else (eq L (HD' :: TL),
          if eq_benign HD HD'
 	 then success
@@ -61,9 +61,9 @@ dbtenv X dbtmagic <-
 
 headargs' : A -> B -> list dyn -> prop.
 headargs' E HD ARGS <-
-  (if eq (dyn HD) (dyn dbtmagic),
-      eq E (dbtmagic ARGS),
-      headargs E HD ARGS).
+  (if eq (dyn HD) (dyn dbtmagic)
+   then eq E (dbtmagic ARGS)
+   else refl.headargs E HD ARGS).
 
 dbtrun (dbt_lookup S ARGS) (dyn E) <-
   dbtenv S HD,
@@ -81,7 +81,7 @@ dbtrun (dbt_magicnu D) E <-
   foldr (fun elm cur => eq (dbt_nu elm cur)) XS D D',
   dbtrun D' E.
 
-argtyps : A -> list dyn -> prop.
+argtyps : {A} A -> list dyn -> prop.
 argtyps (X : unit -> B) TL <-
   (x:unit -> argtyps (X x) TL).
 argtyps (X : A -> B) ( (dyn (Z : A)) :: TL ) <-
@@ -110,7 +110,7 @@ dbt_mk_bindmany : C -> bindmany A B -> prop.
 dbt_mk_bindmany (X : C) (B : bindmany A B) <-
   (if refl.isunif X
    then eq (dyn B) (dyn X)
-   else (if typeq (X : C) (Z : A -> C'),
+   else (if typeq (X : C) (Z : A -> C')
          then (eq B (bcons R), eq (dyn X) (dyn Z'), (x:A -> dbt_mk_bindmany (Z' x) (R x)))
          else (eq (dyn X) (dyn (X' : B)), eq B (bnil X')))).
 

--- a/examples/peg/dbt.makam
+++ b/examples/peg/dbt.makam
@@ -38,7 +38,7 @@ dbtrun (dbt_lam (F : A -> dbt)) (dyn E) <-
 dbtrun (dbt_int I) (dyn (I : int)).
 dbtrun (dbt_string S) (dyn (S : string)).
 
-dbtenv : {A} string -> A -> prop.
+dbtenv : [A] string -> A -> prop.
 dbtmagicenv : list string -> prop.
 dbtmagic : list dyn -> A.
 
@@ -81,7 +81,7 @@ dbtrun (dbt_magicnu D) E <-
   foldr (fun elm cur => eq (dbt_nu elm cur)) XS D D',
   dbtrun D' E.
 
-argtyps : {A} A -> list dyn -> prop.
+argtyps : [A] A -> list dyn -> prop.
 argtyps (X : unit -> B) TL <-
   (x:unit -> argtyps (X x) TL).
 argtyps (X : A -> B) ( (dyn (Z : A)) :: TL ) <-

--- a/examples/peg/pegstaged.makam
+++ b/examples/peg/pegstaged.makam
@@ -20,24 +20,24 @@ compiled  : (list string -> option (tuple (list string) A) -> prop) ->
 	    (list string -> option (tuple (list string) A) -> prop) ->
 	    peg A.
 
-peginline        : {A} peg A -> peg A -> prop.
-peginline_parse  : {A} peg A -> peg A -> prop.
-peginline_pretty : {A} peg A -> peg A -> prop.
+peginline        : [A] peg A -> peg A -> prop.
+peginline_parse  : [A] peg A -> peg A -> prop.
+peginline_pretty : [A] peg A -> peg A -> prop.
 
-pegrule        : {A} peg A -> peg A -> cmd -> prop.
-pegrule_parse  : {A} peg A -> peg A -> cmd -> prop.
-pegrule_pretty : {A} peg A -> peg A -> cmd -> prop.
+pegrule        : [A] peg A -> peg A -> cmd -> prop.
+pegrule_parse  : [A] peg A -> peg A -> cmd -> prop.
+pegrule_pretty : [A] peg A -> peg A -> cmd -> prop.
 
-xparse  : {A} peg A -> (list string -> option (tuple (list string) A) -> prop) -> prop.
-xxparse  : {A} peg A -> (list string -> option (tuple (list string) A) -> prop) -> prop.
-xuparse  : {A} peg A -> (list string -> option (tuple (list string) A) -> prop) -> prop.
-xpretty : {A} peg A -> (list string -> option (tuple (list string) A) -> prop) -> prop.
-xxpretty : {A} peg A -> (list string -> option (tuple (list string) A) -> prop) -> prop.
-xupretty : {A} peg A -> (list string -> option (tuple (list string) A) -> prop) -> prop.
+xparse  : [A] peg A -> (list string -> option (tuple (list string) A) -> prop) -> prop.
+xxparse  : [A] peg A -> (list string -> option (tuple (list string) A) -> prop) -> prop.
+xuparse  : [A] peg A -> (list string -> option (tuple (list string) A) -> prop) -> prop.
+xpretty : [A] peg A -> (list string -> option (tuple (list string) A) -> prop) -> prop.
+xxpretty : [A] peg A -> (list string -> option (tuple (list string) A) -> prop) -> prop.
+xupretty : [A] peg A -> (list string -> option (tuple (list string) A) -> prop) -> prop.
 
-pegbuiltin : {A} peg A -> prop.
+pegbuiltin : [A] peg A -> prop.
 
-parse : {A} peg A -> (string -> option (tuple string A) -> prop) -> prop.
+parse : [A] peg A -> (string -> option (tuple string A) -> prop) -> prop.
 parse P (fun S Res' => {prop| [Chars Res RestChars RealRes S']
         string.explode S Chars,
 	P' Chars Res,
@@ -47,7 +47,7 @@ parse P (fun S Res' => {prop| [Chars Res RestChars RealRes S']
 	) <-
   xparse P P'.
 
-pretty : {A} peg A -> (option (tuple string A) -> string -> prop) -> prop.
+pretty : [A] peg A -> (option (tuple string A) -> string -> prop) -> prop.
 pretty P (fun FullRes Input => {prop| [Output Res OutputC InputC]
   eq FullRes (some (tuple Output Res)),
   string.explode Output OutputC,
@@ -160,8 +160,8 @@ pegbuiltin (compiled _ _).
 xparse  (compiled Parse Pretty) Parse.
 xpretty (compiled Parse Pretty) Pretty.
 
-peginline_xparse  : {A} peg A -> peg A -> prop.
-peginline_xpretty : {A} peg A -> peg A -> prop.
+peginline_xparse  : [A] peg A -> peg A -> prop.
+peginline_xpretty : [A] peg A -> peg A -> prop.
 
 peginline_xparse  P Def <- (if peginline_parse P Def then success else peginline P Def).
 peginline_xpretty P Def <- (if peginline_pretty P Def then success else peginline P Def).
@@ -216,28 +216,28 @@ xpretty (Peg : peg A) (fun Input Result => once(P'' Input Result)) <-
   map pegcompile_pretty Args Args',
   appmany P' Args' P''.
 
-mkclause : {A} A -> A -> clause -> prop.
+mkclause : [A] A -> A -> clause -> prop.
 mkclause (G : prop) (P : prop) (clause G P).
 mkclause (G : A -> B) (P : A -> B) X <- mkclause (G Y) (P Y) X.
 
-mkclausecmd : {A} string -> A -> cmd -> prop.
+mkclausecmd : [A] string -> A -> cmd -> prop.
 mkclausecmd GName P (cmd_newclause Clause) <- refl.lookup GName G, mkclause G P Clause.
 
-mkclausecmd2 : {B} string -> list dyn -> list prop -> (B -> prop) -> cmd -> prop.
+mkclausecmd2 : [B] string -> list dyn -> list prop -> (B -> prop) -> cmd -> prop.
 mkclausecmd2 GName Args Knowns Proc (cmd_newclause Clause) <-
   refl.lookup GName G,
   appmany G Args G',
   assumemany Knowns (Proc X),
   mkclause G' X Clause.
 
-weirdappmanyrev : {A B} A -> list dyn -> B -> prop.
+weirdappmanyrev : [A B] A -> list dyn -> B -> prop.
 weirdappmanyrev (X : A) nil (Y : A).
 weirdappmanyrev (X : A) (cons (dyn (HD : B)) TL) Z <- weirdappmanyrev (Y : B -> A) TL Z.
 weirdappmanyrevreal : A -> list dyn -> B -> prop.
 weirdappmanyrevreal X L Y <- reverse L L', weirdappmanyrev X L' Y.
 
 
-pegdeclare   : {A} peg A -> cmd -> prop.
+pegdeclare   : [A] peg A -> cmd -> prop.
 pegdeclare (Peg : peg A) Cmd <-
   refl.headname Peg Name,
   refl.headargs Peg _ Args,

--- a/examples/peg/pegstaged.makam
+++ b/examples/peg/pegstaged.makam
@@ -20,24 +20,24 @@ compiled  : (list string -> option (tuple (list string) A) -> prop) ->
 	    (list string -> option (tuple (list string) A) -> prop) ->
 	    peg A.
 
-peginline        : peg A -> peg A -> prop.
-peginline_parse  : peg A -> peg A -> prop.
-peginline_pretty : peg A -> peg A -> prop.
+peginline        : {A} peg A -> peg A -> prop.
+peginline_parse  : {A} peg A -> peg A -> prop.
+peginline_pretty : {A} peg A -> peg A -> prop.
 
-pegrule        : peg A -> peg A -> cmd -> prop.
-pegrule_parse  : peg A -> peg A -> cmd -> prop.
-pegrule_pretty : peg A -> peg A -> cmd -> prop.
+pegrule        : {A} peg A -> peg A -> cmd -> prop.
+pegrule_parse  : {A} peg A -> peg A -> cmd -> prop.
+pegrule_pretty : {A} peg A -> peg A -> cmd -> prop.
 
-xparse  : peg A -> (list string -> option (tuple (list string) A) -> prop) -> prop.
-xxparse  : peg A -> (list string -> option (tuple (list string) A) -> prop) -> prop.
-xuparse  : peg A -> (list string -> option (tuple (list string) A) -> prop) -> prop.
-xpretty : peg A -> (list string -> option (tuple (list string) A) -> prop) -> prop.
-xxpretty : peg A -> (list string -> option (tuple (list string) A) -> prop) -> prop.
-xupretty : peg A -> (list string -> option (tuple (list string) A) -> prop) -> prop.
+xparse  : {A} peg A -> (list string -> option (tuple (list string) A) -> prop) -> prop.
+xxparse  : {A} peg A -> (list string -> option (tuple (list string) A) -> prop) -> prop.
+xuparse  : {A} peg A -> (list string -> option (tuple (list string) A) -> prop) -> prop.
+xpretty : {A} peg A -> (list string -> option (tuple (list string) A) -> prop) -> prop.
+xxpretty : {A} peg A -> (list string -> option (tuple (list string) A) -> prop) -> prop.
+xupretty : {A} peg A -> (list string -> option (tuple (list string) A) -> prop) -> prop.
 
-pegbuiltin : peg A -> prop.
+pegbuiltin : {A} peg A -> prop.
 
-parse : peg A -> (string -> option (tuple string A) -> prop) -> prop.
+parse : {A} peg A -> (string -> option (tuple string A) -> prop) -> prop.
 parse P (fun S Res' => {prop| [Chars Res RestChars RealRes S']
         string.explode S Chars,
 	P' Chars Res,
@@ -47,7 +47,7 @@ parse P (fun S Res' => {prop| [Chars Res RestChars RealRes S']
 	) <-
   xparse P P'.
 
-pretty : peg A -> (option (tuple string A) -> string -> prop) -> prop.
+pretty : {A} peg A -> (option (tuple string A) -> string -> prop) -> prop.
 pretty P (fun FullRes Input => {prop| [Output Res OutputC InputC]
   eq FullRes (some (tuple Output Res)),
   string.explode Output OutputC,
@@ -160,8 +160,8 @@ pegbuiltin (compiled _ _).
 xparse  (compiled Parse Pretty) Parse.
 xpretty (compiled Parse Pretty) Pretty.
 
-peginline_xparse  : peg A -> peg A -> prop.
-peginline_xpretty : peg A -> peg A -> prop.
+peginline_xparse  : {A} peg A -> peg A -> prop.
+peginline_xpretty : {A} peg A -> peg A -> prop.
 
 peginline_xparse  P Def <- (if peginline_parse P Def then success else peginline P Def).
 peginline_xpretty P Def <- (if peginline_pretty P Def then success else peginline P Def).
@@ -216,28 +216,28 @@ xpretty (Peg : peg A) (fun Input Result => once(P'' Input Result)) <-
   map pegcompile_pretty Args Args',
   appmany P' Args' P''.
 
-mkclause : A -> A -> clause -> prop.
+mkclause : {A} A -> A -> clause -> prop.
 mkclause (G : prop) (P : prop) (clause G P).
 mkclause (G : A -> B) (P : A -> B) X <- mkclause (G Y) (P Y) X.
 
-mkclausecmd : string -> A -> cmd -> prop.
+mkclausecmd : {A} string -> A -> cmd -> prop.
 mkclausecmd GName P (cmd_newclause Clause) <- refl.lookup GName G, mkclause G P Clause.
 
-mkclausecmd2 : string -> list dyn -> list prop -> (B -> prop) -> cmd -> prop.
+mkclausecmd2 : {B} string -> list dyn -> list prop -> (B -> prop) -> cmd -> prop.
 mkclausecmd2 GName Args Knowns Proc (cmd_newclause Clause) <-
   refl.lookup GName G,
   appmany G Args G',
   assumemany Knowns (Proc X),
   mkclause G' X Clause.
 
-weirdappmanyrev : A -> list dyn -> B -> prop.
+weirdappmanyrev : {A B} A -> list dyn -> B -> prop.
 weirdappmanyrev (X : A) nil (Y : A).
 weirdappmanyrev (X : A) (cons (dyn (HD : B)) TL) Z <- weirdappmanyrev (Y : B -> A) TL Z.
 weirdappmanyrevreal : A -> list dyn -> B -> prop.
 weirdappmanyrevreal X L Y <- reverse L L', weirdappmanyrev X L' Y.
 
 
-pegdeclare   : peg A -> cmd -> prop.
+pegdeclare   : {A} peg A -> cmd -> prop.
 pegdeclare (Peg : peg A) Cmd <-
   refl.headname Peg Name,
   refl.headargs Peg _ Args,

--- a/grammars/fixedLamProlog.peg
+++ b/grammars/fixedLamProlog.peg
@@ -125,9 +125,9 @@ annotexpr -> e:lexpr^ token(":") t:lmonotyp << autospan_bin mkAnnot e t >>
 
 typ  -> t:ltyp << t.content >>
 
-ltyp  -> s:ltoken("[") parametric:repWHITE(token(ident)) e:ltoken("]") t:lmonotyp
-        << let param = { content = parametric ; span = s ---> e } in 
-           autospan_bin _tForall param t >>
+ltyp  -> s:ltoken("{") adhoc:repWHITE(token(ident)) e:ltoken("}") t:lmonotyp
+        << let adhoc = { content = adhoc ; span = s ---> e } in 
+           autospan_bin _tForallAdhoc adhoc t >>
       / t:lmonotyp << t >>
 
 lmonotyp -> t:multtyp^ token("->") e:lmonotyp     << autospan_bin _tArrow t e >>

--- a/grammars/fixedLamProlog.peg
+++ b/grammars/fixedLamProlog.peg
@@ -125,7 +125,7 @@ annotexpr -> e:lexpr^ token(":") t:lmonotyp << autospan_bin mkAnnot e t >>
 
 typ  -> t:ltyp << t.content >>
 
-ltyp  -> s:ltoken("{") adhoc:repWHITE(token(ident)) e:ltoken("}") t:lmonotyp
+ltyp  -> s:ltoken("[") adhoc:repWHITE(token(ident)) e:ltoken("]") t:lmonotyp
         << let adhoc = { content = adhoc ; span = s ---> e } in 
            autospan_bin _tForallAdhoc adhoc t >>
       / t:lmonotyp << t >>

--- a/stdlib/basic_predicates.makam
+++ b/stdlib/basic_predicates.makam
@@ -1,14 +1,14 @@
 eq : A -> A -> prop.
 eq X X.
 
-apply : [A1 A2 B] (A1 -> A2 -> B) -> A1 -> A2 -> B -> prop.
+apply : (A1 -> A2 -> B) -> A1 -> A2 -> B -> prop.
 apply F X1 X2 (F X1 X2).
 
-apply : [A1 A2 A3 B] (A1 -> A2 -> A3 -> B) -> A1 -> A2 -> A3 -> B -> prop.
+apply : (A1 -> A2 -> A3 -> B) -> A1 -> A2 -> A3 -> B -> prop.
 apply F X1 X2 X3 (F X1 X2 X3).
 
-apply : [A1 A2 A3 A4 B] (A1 -> A2 -> A3 -> A4 -> B) -> A1 -> A2 -> A3 -> A4 -> B -> prop.
+apply : (A1 -> A2 -> A3 -> A4 -> B) -> A1 -> A2 -> A3 -> A4 -> B -> prop.
 apply F X1 X2 X3 X4 (F X1 X2 X3 X4).
 
-apply : [A B] (A -> B) -> A -> B -> prop.
+apply : (A -> B) -> A -> B -> prop.
 apply F X (F X).

--- a/stdlib/bind.makam
+++ b/stdlib/bind.makam
@@ -23,19 +23,19 @@ varname (bindone S _) S.
 match_binders : bindone A B -> bindone A' B' -> prop.
 match_binders (bindone S _) (bindone S _).
 
-open_aux : {PropType} A -> list dyn -> PropType -> prop.
+open_aux : [PropType] A -> list dyn -> PropType -> prop.
 open_aux Var [] P <- P.
 open_aux Var (dyn B :: TL) P <-
   apply B Var X,
   open_aux Var TL (P X).
 
-opendyn : {PropType} list dyn -> PropType -> prop.
+opendyn : [PropType] list dyn -> PropType -> prop.
 opendyn ES P <-
   eq ES (dyn HD :: _),
   dyn.iter (match_binders HD) ES,
   newvar HD (fun x => open_aux x ES (P x)).
 
-opendyn_nomatch : {PropType} list dyn -> PropType -> prop.
+opendyn_nomatch : [PropType] list dyn -> PropType -> prop.
 opendyn_nomatch ES P <-
   eq ES (dyn HD :: _),
   newvar HD (fun x => open_aux x ES (P x)).
@@ -99,19 +99,19 @@ match_binders (bindend  _) (bindend _).
 match_binders (bindnext S F) (bindnext S F') <- (x:A -> x':A' -> match_binders (F x) (F' x')).
 
 
-open_aux : {PropType} list A -> list dyn -> PropType -> prop.
+open_aux : [PropType] list A -> list dyn -> PropType -> prop.
 open_aux Vars [] P <- P.
 open_aux Vars (dyn B :: TL) P <-
   apply B Vars X,
   open_aux Vars TL (P X).
 
-opendyn : {PropType} list dyn -> PropType -> prop.
+opendyn : [PropType] list dyn -> PropType -> prop.
 opendyn ES P <-
   eq ES (dyn HD :: _),
   dyn.iter (match_binders HD) ES,
   newvars HD (fun xs => open_aux xs ES (P xs)).
 
-opendyn_nomatch : {PropType} list dyn -> PropType -> prop.
+opendyn_nomatch : [PropType] list dyn -> PropType -> prop.
 opendyn_nomatch ES P <-
   eq ES (dyn HD :: _),
   newvars HD (fun xs => open_aux xs ES (P xs)).
@@ -178,19 +178,19 @@ match_binders : telescope V T A -> telescope V' T' A' -> prop.
 match_binders (telend  _) (telend _).
 match_binders (telnext S _ F) (telnext S _ F') <- (x:A -> x':A' -> match_binders (F x) (F' x')).
 
-open_aux : {PropType} list A -> list dyn -> PropType -> prop.
+open_aux : [PropType] list A -> list dyn -> PropType -> prop.
 open_aux Vars [] P <- P.
 open_aux Vars (dyn HD :: TL) P <-
   apply HD Vars X,
   open_aux Vars TL (P X).
 
-opendyn : {PropType} list dyn -> PropType -> prop.
+opendyn : [PropType] list dyn -> PropType -> prop.
 opendyn ES P <-
   eq ES (dyn HD :: _),
   dyn.iter (match_binders HD) ES,
   newvars HD (fun xs => open_aux xs ES (P xs)).
 
-opendyn_nomatch : {PropType} list dyn -> PropType -> prop.
+opendyn_nomatch : [PropType] list dyn -> PropType -> prop.
 opendyn_nomatch ES P <-
   eq ES (dyn HD :: _),
   newvars HD (fun x => open_aux x ES (P x)).

--- a/stdlib/bind.makam
+++ b/stdlib/bind.makam
@@ -9,9 +9,9 @@ bindone : string -> (A -> B) -> bindone A B.
 
 %extend bindone.
 
-newvar : [A B] bindone A B -> (A -> prop) -> prop.
-varname : [A] bindone A B -> string -> prop.
-apply : [A B] bindone A B -> A -> B -> prop.
+newvar : bindone A B -> (A -> prop) -> prop.
+varname : bindone A B -> string -> prop.
+apply : bindone A B -> A -> B -> prop.
 
 newvar (bindone Name (F : A -> B)) (P : A -> prop) <-
   (x:A -> nameofvar x Name -> P x).
@@ -20,22 +20,22 @@ apply (bindone _ F) X (F X).
 
 varname (bindone S _) S.
 
-match_binders : [A B A' B'] bindone A B -> bindone A' B' -> prop.
+match_binders : bindone A B -> bindone A' B' -> prop.
 match_binders (bindone S _) (bindone S _).
 
-open_aux : [A] A -> list dyn -> PropType -> prop.
+open_aux : {PropType} A -> list dyn -> PropType -> prop.
 open_aux Var [] P <- P.
 open_aux Var (dyn B :: TL) P <-
   apply B Var X,
   open_aux Var TL (P X).
 
-opendyn : list dyn -> PropType -> prop.
+opendyn : {PropType} list dyn -> PropType -> prop.
 opendyn ES P <-
   eq ES (dyn HD :: _),
   dyn.iter (match_binders HD) ES,
   newvar HD (fun x => open_aux x ES (P x)).
 
-opendyn_nomatch : list dyn -> PropType -> prop.
+opendyn_nomatch : {PropType} list dyn -> PropType -> prop.
 opendyn_nomatch ES P <-
   eq ES (dyn HD :: _),
   newvar HD (fun x => open_aux x ES (P x)).
@@ -75,11 +75,11 @@ bindnext : string -> (A -> bindmany A B) -> bindmany A B.
 
 %extend bindmany.
 
-newvars : [A B] bindmany A B -> (list A -> prop) -> prop.
-apply : [A B] bindmany A B -> list A -> B -> prop.
-varnames : [A B] bindmany A B -> list string -> prop.
+newvars : bindmany A B -> (list A -> prop) -> prop.
+apply : bindmany A B -> list A -> B -> prop.
+varnames : bindmany A B -> list string -> prop.
 
-newvars_aux : [A B] bindmany A B -> list A -> (list A -> prop) -> prop.
+newvars_aux : bindmany A B -> list A -> (list A -> prop) -> prop.
 newvars_aux (bindend _) Vars P <- reverse Vars Vars', P Vars'.
 newvars_aux (bindnext S Rest) Vars P <-
   bindone.open (bindone S Rest) (fun x bindrest => newvars_aux bindrest (x :: Vars) P).
@@ -88,30 +88,30 @@ newvars B P <- newvars_aux B [] P.
 apply (bindend X) [] X.
 apply (bindnext _ F) (HD :: TL) Res <- apply (F HD) TL Res.
 
-applysome : [A B] bindmany A B -> list A -> bindmany A B -> prop.
+applysome : bindmany A B -> list A -> bindmany A B -> prop.
 applysome (bindnext _ F) (HD :: TL) Res <- applysome (F HD) TL Res.
 applysome X nil X.
 
 varnames B Names <- newvars B (fun xs => map nameofvar xs Names).
 
-match_binders : [A B A' B'] bindmany A B -> bindmany A' B' -> prop.
+match_binders : bindmany A B -> bindmany A' B' -> prop.
 match_binders (bindend  _) (bindend _).
 match_binders (bindnext S F) (bindnext S F') <- (x:A -> x':A' -> match_binders (F x) (F' x')).
 
 
-open_aux : [A] list A -> list dyn -> PropType -> prop.
+open_aux : {PropType} list A -> list dyn -> PropType -> prop.
 open_aux Vars [] P <- P.
 open_aux Vars (dyn B :: TL) P <-
   apply B Vars X,
   open_aux Vars TL (P X).
 
-opendyn : list dyn -> PropType -> prop.
+opendyn : {PropType} list dyn -> PropType -> prop.
 opendyn ES P <-
   eq ES (dyn HD :: _),
   dyn.iter (match_binders HD) ES,
   newvars HD (fun xs => open_aux xs ES (P xs)).
 
-opendyn_nomatch : list dyn -> PropType -> prop.
+opendyn_nomatch : {PropType} list dyn -> PropType -> prop.
 opendyn_nomatch ES P <-
   eq ES (dyn HD :: _),
   newvars HD (fun xs => open_aux xs ES (P xs)).
@@ -153,12 +153,12 @@ telnext  : string -> V -> (V -> telescope V T B) -> telescope V T B.
 
 %extend telescope.
 
-newvars : [V T B] telescope V T B -> (list V -> prop) -> prop.
-apply : [V T B] telescope V T B -> list A -> B -> prop.
-varnames : [V T B] telescope V T B -> list string -> prop.
-varinfos : [V T B] telescope V T B -> list T -> prop.
+newvars : telescope V T B -> (list V -> prop) -> prop.
+apply : telescope V T B -> list V -> B -> prop.
+varnames : telescope V T B -> list string -> prop.
+varinfos : telescope V T B -> list T -> prop.
 
-newvars_aux : [V T B] telescope V T B -> list V -> (list V -> prop) -> prop.
+newvars_aux : telescope V T B -> list V -> (list V -> prop) -> prop.
 newvars_aux (telend _) Vars P <- reverse Vars Vars', P Vars'.
 newvars_aux (telnext S T Rest) Vars P <-
   bindone.open (bindone S Rest) (pfun x bindrest => (infoofvar x T -> newvars_aux bindrest (x :: Vars) P) ).
@@ -167,30 +167,30 @@ newvars B P <- newvars_aux B [] P.
 apply (telend X) [] X.
 apply (telnext _ _ F) (HD :: TL) Res <- apply (F HD) TL Res.
 
-applysome : [V T B] telescope V T B -> list A -> telescope V T B -> prop.
+applysome : telescope V T B -> list V -> telescope V T B -> prop.
 applysome (telnext _ _ F) (HD :: TL) Res <- applysome (F HD) TL Res.
 applysome X nil X.
 
 varnames B Names <- newvars B (fun xs => map nameofvar xs Names).
 varinfos B Names <- newvars B (fun xs => map infoofvar xs Names).
 
-match_binders : [V T A V' T' A'] telescope V T A -> telescope V' T' A' -> prop.
+match_binders : telescope V T A -> telescope V' T' A' -> prop.
 match_binders (telend  _) (telend _).
 match_binders (telnext S _ F) (telnext S _ F') <- (x:A -> x':A' -> match_binders (F x) (F' x')).
 
-open_aux : [A] list A -> list dyn -> PropType -> prop.
+open_aux : {PropType} list A -> list dyn -> PropType -> prop.
 open_aux Vars [] P <- P.
 open_aux Vars (dyn HD :: TL) P <-
   apply HD Vars X,
   open_aux Vars TL (P X).
 
-opendyn : list dyn -> PropType -> prop.
+opendyn : {PropType} list dyn -> PropType -> prop.
 opendyn ES P <-
   eq ES (dyn HD :: _),
   dyn.iter (match_binders HD) ES,
   newvars HD (fun xs => open_aux xs ES (P xs)).
 
-opendyn_nomatch : list dyn -> PropType -> prop.
+opendyn_nomatch : {PropType} list dyn -> PropType -> prop.
 opendyn_nomatch ES P <-
   eq ES (dyn HD :: _),
   newvars HD (fun x => open_aux x ES (P x)).

--- a/stdlib/connectives.makam
+++ b/stdlib/connectives.makam
@@ -22,7 +22,7 @@ assume_many_clauses : list clause -> prop -> prop.
 assume_many_clauses [] P <- P.
 assume_many_clauses (HD :: TL) P <- assume HD (assume_many_clauses TL P).
 
-assume_many : [A B] (A -> B -> prop) -> list A -> list B -> prop -> prop.
+assume_many : (A -> B -> prop) -> list A -> list B -> prop -> prop.
 assume_many P [] [] G <- G.
 assume_many P (A :: AS) (B :: BS) G <- (P A B -> assume_many P AS BS G).
 

--- a/stdlib/dyn.makam
+++ b/stdlib/dyn.makam
@@ -1,16 +1,16 @@
 %extend dyn.
 (* A version of `eq` that delays type unification of the terms until runtime *)
-eq : {B} A -> B -> prop.
+eq : [B] A -> B -> prop.
 eq X X.
 
 (* Similarly, a dynamically-typed version of application. *)
-apply : {A C} A -> B -> C -> prop.
+apply : [A C] A -> B -> C -> prop.
 apply F X (F X).
 
 (* Magic: fake rank-N polymorphism by duplicating all heads found, therefore
    generating new polymorphic variables for them. *)
-poly : {A B} A -> B -> prop.
-polybvar : {A B} A -> B -> prop.
+poly : [A B] A -> B -> prop.
+polybvar : [A B] A -> B -> prop.
 map_poly : list dyn -> list dyn -> prop.
 
 poly E E' when refl.isbaseterm E, refl.isnvar E <-
@@ -57,14 +57,14 @@ foldl F X L X' <- .foldl (call_dyn F) (dyn X) L (dyn X').
 %end.
 
 (* Apply many arguments *)
-apply_many : {A B} A -> list dyn -> B -> prop.
+apply_many : [A B] A -> list dyn -> B -> prop.
 apply_many X nil X.
 apply_many (X : A -> B) (dyn HD :: TL) Res <- dyn.apply X HD X', apply_many X' TL Res.
 
 (* Apply all arguments -- when the argument list is not specified,
    this will repeatedly apply arguments, generating new unification
    variables, for the full arity of the functional argument. *)
-apply_all : {A B} A -> list dyn -> B -> prop.
+apply_all : [A B] A -> list dyn -> B -> prop.
 apply_all (X : A -> B) (dyn HD :: TL) Res <- dyn.apply X HD X', apply_all X' TL Res.
 (apply_all X nil X) when not(typ.eq X (_ : A -> B)).
 

--- a/stdlib/dyn.makam
+++ b/stdlib/dyn.makam
@@ -1,16 +1,16 @@
 %extend dyn.
 (* A version of `eq` that delays type unification of the terms until runtime *)
-eq : A -> B -> prop.
+eq : {B} A -> B -> prop.
 eq X X.
 
 (* Similarly, a dynamically-typed version of application. *)
-apply : A -> B -> C -> prop.
+apply : {A C} A -> B -> C -> prop.
 apply F X (F X).
 
 (* Magic: fake rank-N polymorphism by duplicating all heads found, therefore
    generating new polymorphic variables for them. *)
-poly : A -> B -> prop.
-polybvar : A -> B -> prop.
+poly : {A B} A -> B -> prop.
+polybvar : {A B} A -> B -> prop.
 map_poly : list dyn -> list dyn -> prop.
 
 poly E E' when refl.isbaseterm E, refl.isnvar E <-
@@ -57,14 +57,14 @@ foldl F X L X' <- .foldl (call_dyn F) (dyn X) L (dyn X').
 %end.
 
 (* Apply many arguments *)
-apply_many : A -> list dyn -> B -> prop.
+apply_many : {A B} A -> list dyn -> B -> prop.
 apply_many X nil X.
 apply_many (X : A -> B) (dyn HD :: TL) Res <- dyn.apply X HD X', apply_many X' TL Res.
 
 (* Apply all arguments -- when the argument list is not specified,
    this will repeatedly apply arguments, generating new unification
    variables, for the full arity of the functional argument. *)
-apply_all : A -> list dyn -> B -> prop.
+apply_all : {A B} A -> list dyn -> B -> prop.
 apply_all (X : A -> B) (dyn HD :: TL) Res <- dyn.apply X HD X', apply_all X' TL Res.
 (apply_all X nil X) when not(typ.eq X (_ : A -> B)).
 

--- a/stdlib/eq_typeclass.makam
+++ b/stdlib/eq_typeclass.makam
@@ -16,9 +16,9 @@ eqT : (A -> A -> prop) -> eqT A.
     eqT_instance is used to declare instances of the typeclass
     eqT_default is used to declare a fallback, default instance if no specialized instance is found. *)
 
-eqT_lookup       : {A} eqT A -> prop.
-eqT_instance     : {A} eqT A -> prop.
-eqT_default      : {A} eqT A -> prop.
+eqT_lookup       : [A] eqT A -> prop.
+eqT_instance     : [A] eqT A -> prop.
+eqT_default      : [A] eqT A -> prop.
 
 eqT_lookup Instance <-
   once (unless_many [

--- a/stdlib/eq_typeclass.makam
+++ b/stdlib/eq_typeclass.makam
@@ -16,9 +16,9 @@ eqT : (A -> A -> prop) -> eqT A.
     eqT_instance is used to declare instances of the typeclass
     eqT_default is used to declare a fallback, default instance if no specialized instance is found. *)
 
-eqT_lookup       : eqT A -> prop.
-eqT_instance     : eqT A -> prop.
-eqT_default      : eqT A -> prop.
+eqT_lookup       : {A} eqT A -> prop.
+eqT_instance     : {A} eqT A -> prop.
+eqT_default      : {A} eqT A -> prop.
 
 eqT_lookup Instance <-
   once (unless_many [

--- a/stdlib/fluid.makam
+++ b/stdlib/fluid.makam
@@ -2,12 +2,12 @@ fluid : type -> type.
 
 %extend fluid.
 
-new : [A] A -> (fluid A -> prop) -> prop.
-get : [A] fluid A -> A -> prop.
-set : [A] fluid A -> A -> prop -> prop.
-modify : [A] fluid A -> (A -> A -> prop) -> prop -> prop.
+new : A -> (fluid A -> prop) -> prop.
+get : fluid A -> A -> prop.
+set : fluid A -> A -> prop -> prop.
+modify : fluid A -> (A -> A -> prop) -> prop -> prop.
 
-current_value : [A] fluid A -> A -> prop.
+current_value : fluid A -> A -> prop.
 
 new (Init : A) Pred <- (x:(fluid A) -> current_value x Init -> Pred x).
 get X Value <- once(current_value X Value).

--- a/stdlib/generic.makam
+++ b/stdlib/generic.makam
@@ -28,7 +28,7 @@
 *)
 
 
-structural : {B} (A -> A -> prop) -> B -> B -> prop.
+structural : [B] (A -> A -> prop) -> B -> B -> prop.
 
 (* defer if both input and output are uninstantiated metavariables *)
 structural Rec (X : A) (Y : A) when refl.isunif X, refl.isunif Y <-
@@ -54,7 +54,7 @@ structural Rec X Y when refl.isunif X, refl.isbaseterm Y <-
 
 
 %extend generic.
-fold : {A A'} (B -> A -> B -> prop) -> B -> A' -> B -> prop.
+fold : [A A'] (B -> A -> B -> prop) -> B -> A' -> B -> prop.
 
 fold F Acc X Acc' when refl.isunif X <-
   guard X (dyn.call F Acc X Acc').
@@ -70,7 +70,7 @@ fold F Acc X Acc' when refl.isbaseterm X <-
 %end.
 
 
-eq_nounif : {A} A -> A -> prop.
+eq_nounif : [A] A -> A -> prop.
 
 eq_nounif (X : A) (Y : A)
   when refl.isunif X, refl.isunif Y, refl.decomposeunif X I XArgs, refl.decomposeunif Y I YArgs <-

--- a/stdlib/generic.makam
+++ b/stdlib/generic.makam
@@ -28,7 +28,7 @@
 *)
 
 
-structural : (A -> A -> prop) -> B -> B -> prop.
+structural : {B} (A -> A -> prop) -> B -> B -> prop.
 
 (* defer if both input and output are uninstantiated metavariables *)
 structural Rec (X : A) (Y : A) when refl.isunif X, refl.isunif Y <-
@@ -54,7 +54,7 @@ structural Rec X Y when refl.isunif X, refl.isbaseterm Y <-
 
 
 %extend generic.
-fold : (B -> A -> B -> prop) -> B -> A' -> B -> prop.
+fold : {A A'} (B -> A -> B -> prop) -> B -> A' -> B -> prop.
 
 fold F Acc X Acc' when refl.isunif X <-
   guard X (dyn.call F Acc X Acc').
@@ -70,7 +70,7 @@ fold F Acc X Acc' when refl.isbaseterm X <-
 %end.
 
 
-eq_nounif : A -> A -> prop.
+eq_nounif : {A} A -> A -> prop.
 
 eq_nounif (X : A) (Y : A)
   when refl.isunif X, refl.isunif Y, refl.decomposeunif X I XArgs, refl.decomposeunif Y I YArgs <-

--- a/stdlib/guard.makam
+++ b/stdlib/guard.makam
@@ -1,6 +1,6 @@
 guardmany : TupleType -> prop -> prop.
 
-guardmany_aux : TupleType -> unit -> prop -> prop.
+guardmany_aux : {TupleType} TupleType -> unit -> prop -> prop.
 
 guardmany_aux X Trigger P when not(typ.eq X (_ : A * B)) <-
   removableguard Trigger X {prop| P, eq Trigger unit |}.

--- a/stdlib/guard.makam
+++ b/stdlib/guard.makam
@@ -1,6 +1,6 @@
 guardmany : TupleType -> prop -> prop.
 
-guardmany_aux : {TupleType} TupleType -> unit -> prop -> prop.
+guardmany_aux : [TupleType] TupleType -> unit -> prop -> prop.
 
 guardmany_aux X Trigger P when not(typ.eq X (_ : A * B)) <-
   removableguard Trigger X {prop| P, eq Trigger unit |}.

--- a/stdlib/list.makam
+++ b/stdlib/list.makam
@@ -2,7 +2,7 @@
 
 (* Append a list to the end of another list. *)
 
-append : [A] list A -> list A -> list A -> prop.
+append : list A -> list A -> list A -> prop.
 append [] Y Y.
 append (HD::TL) Y (HD::TL') <- append TL Y TL'.
 
@@ -13,52 +13,52 @@ append (HD::TL) Y (HD::TL') <- append TL Y TL'.
    This way if no typing constraints are present, the common version will be picked
    by default. *)
 
-map : [A] (A -> prop) -> list A -> prop.
+map : (A -> prop) -> list A -> prop.
 map P [].
 map P (HD :: TL) <- P HD, map P TL.
 
-map : [A B C] (A -> B -> C -> prop) -> list A -> list B -> list C -> prop.
+map : (A -> B -> C -> prop) -> list A -> list B -> list C -> prop.
 map P [] [] [].
 map P (HD1 :: TL1) (HD2 :: TL2) (HD3 :: TL3) <- P HD1 HD2 HD3, map P TL1 TL2 TL3.
 
-map : [A B C D] (A -> B -> C -> D -> prop) -> list A -> list B -> list C -> list D -> prop.
+map : (A -> B -> C -> D -> prop) -> list A -> list B -> list C -> list D -> prop.
 map P [] [] [] [].
 map P (HD1 :: TL1) (HD2 :: TL2) (HD3 :: TL3) (HD4 :: TL4) <- P HD1 HD2 HD3 HD4, map P TL1 TL2 TL3 TL4.
 
-map : [A B] (A -> B -> prop) -> list A -> list B -> prop.
+map : (A -> B -> prop) -> list A -> list B -> prop.
 map P [] [].
 map P (HD :: TL) (HD' :: TL') <- P HD HD', map P TL TL'.
 
 (* Folds and fold inversion *)
 
-foldr : [A B] (A -> B -> B -> prop) -> list A -> B -> B -> prop.
+foldr : (A -> B -> B -> prop) -> list A -> B -> B -> prop.
 foldr P nil S S.
 foldr P (cons HD TL) S S'' <- foldr P TL S S', P HD S' S''.
 
-foldr_invert : [A B] (A -> B -> B -> prop) -> B -> list A -> B -> prop.
+foldr_invert : (A -> B -> B -> prop) -> B -> list A -> B -> prop.
 foldr_invert P SStart Res SEnd <-
   if P Hd SNext SStart
   then (foldr_invert P SNext Tl SEnd, eq Res (cons Hd Tl))
   else (eq Res nil, eq SStart SEnd).
 
-foldl : [A B] (B -> A -> B -> prop) -> B -> list A -> B -> prop.
+foldl : (B -> A -> B -> prop) -> B -> list A -> B -> prop.
 foldl P S nil S.
 foldl P S (cons HD TL) S'' <- P S HD S', foldl P S' TL S''.
 
-foldl_invert : [A B] (B -> A -> B -> prop) -> B -> list A -> B -> prop.
+foldl_invert : (B -> A -> B -> prop) -> B -> list A -> B -> prop.
 foldl_invert P SEnd Res SStart <-
   if P SPrev Last SEnd
   then (foldl_invert P SPrev Res' SStart, append Res' [Last] Res)
   else (eq Res nil, eq SStart SEnd).
 
 (* Length *)
-length : [A] list A -> int -> prop.
+length : list A -> int -> prop.
 length [] 0.
 length (HD :: TL) N <- length TL N', plus N' 1 N.
 
 (* Reverse the list *)
-reverse : [A] list A -> list A -> prop.
-reverse_aux : [A] list A -> list A -> list A -> prop.
+reverse : list A -> list A -> prop.
+reverse_aux : list A -> list A -> list A -> prop.
 reverse_aux [] L L.
 reverse_aux (HD :: TL) L L' <- reverse_aux TL (HD :: L) L'.
 reverse L L' <- reverse_aux L [] L'.
@@ -66,30 +66,30 @@ reverse L L' <- reverse_aux L [] L'.
 
 (* Convert to catenable list -- list with a hole. Useful for some optimized
    implementations. *)
-catenable : [A] list A -> (list A -> list A) -> prop.
+catenable : list A -> (list A -> list A) -> prop.
 catenable [] (fun x => x).
 catenable (HD :: TL) (fun x => HD :: (TL' x)) <- catenable TL TL'.
 
 (* Concatenate many lists / flatten *)
-concat : [A] list (list A) -> list A -> prop.
+concat : list (list A) -> list A -> prop.
 concat LS L <-
   map catenable LS LS', reverse LS' LS'rev,
   foldl (fun cur lst => eq (lst cur)) nil LS'rev L.
 
 
 (* Find element matching a predicate *)
-find : [A] (A -> prop) -> list A -> A -> prop.
+find : (A -> prop) -> list A -> A -> prop.
 find Pred (HD :: TL) Res <- if (Pred HD) then eq Res HD else find Pred TL Res.
 
 (* Keep only elements that succeed on a predicate *)
-filter : [A] (A -> prop) -> list A -> list A -> prop.
+filter : (A -> prop) -> list A -> list A -> prop.
 filter Pred (HD :: TL) Res <-
   if (Pred HD)
   then (eq Res (HD :: TL'), filter Pred TL TL')
   else (filter Pred TL Res).
 
 (* Combination of filter and map *)
-filtermap : [A] (A -> B -> prop) -> list A -> list B -> prop.
+filtermap : (A -> B -> prop) -> list A -> list B -> prop.
 filtermap Pred (HD :: TL) Res <-
   if (Pred HD HD')
   then (eq Res (HD' :: TL'), filtermap Pred TL TL')
@@ -97,13 +97,13 @@ filtermap Pred (HD :: TL) Res <-
 
 
 (* Succeeds if a list contains an element *)
-contains : [A] eqT A -> A -> list A -> prop.
-contains_aux : [A] eqT A -> A -> list A -> prop.
+contains : eqT A -> A -> list A -> prop.
+contains_aux : eqT A -> A -> list A -> prop.
 contains_aux (eqT EQ) X (HD :: TL) <- unless (EQ X HD) (contains_aux (eqT EQ) X TL).
 contains Eq X L <- eqT_lookup Eq, contains_aux Eq X L.
 
 (* Returns a list with the unique elements *)
-unique : [A] eqT A -> list A -> list A -> prop.
+unique : eqT A -> list A -> list A -> prop.
 unique Eq L L' <-
   eqT_lookup Eq,
   foldl (pfun cur elm res => (if contains Eq elm cur then eq res cur else eq res (elm :: cur)) )
@@ -113,14 +113,14 @@ unique Eq L L' <-
 
 (* Relates a number of lists to a lists where the corresponding elements are tupled together. Overloaded up to 4 lists. *)
 (* Can be used in the opposite direction to unzip into multiple lists. *)
-zip : [A B] list A -> list B -> list C -> list (A * B * C) -> prop.
+zip : list A -> list B -> list C -> list (A * B * C) -> prop.
 zip [] [] [] [].
 zip (HD1 :: TL1) (HD2 :: TL2) (HD3 :: TL3) ((HD1, HD2, HD3) :: TL) <- zip TL1 TL2 TL3 TL.
 
-zip : [A B] list A -> list B -> list C -> list D -> list (A * B * C * D) -> prop.
+zip : list A -> list B -> list C -> list D -> list (A * B * C * D) -> prop.
 zip [] [] [] [] [].
 zip (HD1 :: TL1) (HD2 :: TL2) (HD3 :: TL3) (HD4 :: TL4) ((HD1, HD2, HD3, HD4) :: TL) <- zip TL1 TL2 TL3 TL4 TL.
 
-zip : [A B] list A -> list B -> list (A * B) -> prop.
+zip : list A -> list B -> list (A * B) -> prop.
 zip [] [] [].
 zip (HD1 :: TL1) (HD2 :: TL2) ((HD1, HD2) :: TL) <- zip TL1 TL2 TL.

--- a/stdlib/map.makam
+++ b/stdlib/map.makam
@@ -6,19 +6,19 @@ map : eqT A -> eqT B -> list (A * B) -> map A B.
 
 %extend map.
 
-eq_headkey : [A B] map A B -> A -> prop.
+eq_headkey : map A B -> A -> prop.
 eq_headkey (map (eqT EQkey) EqVal ((Key, _) :: _)) Key' <-
   EQkey Key Key'.
 
-eq_headval : [A B] map A B -> B -> prop.
+eq_headval : map A B -> B -> prop.
 eq_headval (map EqKey (eqT EQval) ((_, Val) :: _)) Val' <-
   EQval Val Val'.
 
-headtail : [A B] map A B -> A * B -> map A B -> prop.
+headtail : map A B -> A * B -> map A B -> prop.
 headtail (map EqKey EqVal (Head :: Tail)) Head (map EqKey EqVal Tail).
 
 (* Remove the  key-value pair matching the key. *)
-remove : [A B] map A B -> A * B -> map A B -> prop.
+remove : map A B -> A * B -> map A B -> prop.
 remove Map (Key, Val) Map' <-
   if eq_headkey Map Key
   then (eq_headval Map Val, headtail Map _ Map')
@@ -26,48 +26,48 @@ remove Map (Key, Val) Map' <-
         headtail Map' Head Tail').
 
 (* Find the value corresponding to a key in a map *)
-find : [A B] map A B -> A -> B -> prop.
+find : map A B -> A -> B -> prop.
 find Map Key Val <-
   remove Map (Key, Val) _.
 
 (* Check whether a key exists in the map *)
-elem : [A B] map A B -> A -> prop.
+elem : map A B -> A -> prop.
 elem (Map : map A B) Key <- find Map Key _.
 
 (* Compute the difference between two maps *)
-diff : [A B] map A B -> map A B -> map A B -> prop.
+diff : map A B -> map A B -> map A B -> prop.
 diff MapA MapB MapR <-
   eq (MapA, MapB) (map EQ1 EQ2 _, map EQ1 EQ2 MapBList),
   foldl remove MapA MapBList MapR. 
 
 (* Resets a map to be empty; useful also for creating an empty map out of a given one. *)
-reset : [A B] map A B -> map A B -> prop.
+reset : map A B -> map A B -> prop.
 reset (map Eq1 Eq2 _) (map Eq1 Eq2 []).
 
 (* Check whether two maps are equal *)
-equal : [A B] map A B -> map A B -> prop.
+equal : map A B -> map A B -> prop.
 equal MapA MapB <-
   reset MapA Empty,
   diff MapA MapB Empty.
 
 (* Succeeds if the map is empty; also could be used to create an empty map. *)
-empty : [A B] eqT A -> eqT B -> map A B -> prop.
+empty : eqT A -> eqT B -> map A B -> prop.
 empty Eq1 Eq2 (map Eq1 Eq2 []) <-
   eqT_lookup Eq1, eqT_lookup Eq2.
 
-fromlist : [A B] eqT A -> eqT B -> list (A * B) -> map A B -> prop.
+fromlist : eqT A -> eqT B -> list (A * B) -> map A B -> prop.
 fromlist Eq1 Eq2 L (map Eq1 Eq2 L) <-
   eqT_lookup Eq1, eqT_lookup Eq2.
 
 (* Map each value in the map through a predicate. *)
-mapvalues : [K A B] (A -> B -> prop) -> map K A -> map K B -> prop.
+mapvalues : (A -> B -> prop) -> map K A -> map K B -> prop.
 mapvalues P (map Eq1 Eq2 List) (map Eq1 Eq2' List') <-
   eqT_lookup Eq2',
   map (pfun elm res => [Key Val Val'] eq elm (Key, Val), P Val Val', eq res (Key, Val')) List List'.
 
 (* Relates a map to a map that includes the given (key, value) pair,
    unless the map includes a different entry for the key already. *)
-add : [A B] map A B -> A * B -> map A B -> prop.
+add : map A B -> A * B -> map A B -> prop.
 add Map (Key, Val) Result <-
   if elem Map Key
   then (find Map Key Val, eq Result Map)
@@ -81,7 +81,7 @@ union MapA MapB MapResult <-
 
 (* Relates a map to a map that includes the given (key, value) pair,
    changing the entry for the key if one exists already. *)
-update : [A B] map A B -> A * B -> map A B -> prop.
+update : map A B -> A * B -> map A B -> prop.
 update Map (Key, Val) Result <-
   if elem Map Key
   then (remove Map (Key, _) Map',

--- a/stdlib/morerefl.makam
+++ b/stdlib/morerefl.makam
@@ -11,9 +11,9 @@ sameunif X Y <-
 %extend userdef.
 
 (* reimplement two builtin predicates just to show that it's possible to do *)
-getunif : {A B} A -> B -> prop.
+getunif : [A B] A -> B -> prop.
 
-getunif_aux, getunif_ : {A B} option B -> A -> option B -> prop.
+getunif_aux, getunif_ : [A B] option B -> A -> option B -> prop.
 
 getunif_aux X Y Z <- demand.case_otherwise (getunif_ X Y Z) (generic.fold getunif_aux X Y Z).
 getunif_ (some Res) _ (some Res).
@@ -21,8 +21,8 @@ getunif_ _ X (some X) when refl.isunif X.
 
 getunif Root Unif <- getunif_aux none Root (some Unif).
 
-absunif : {A B} A -> B -> (B -> A) -> prop.
-absunif_aux, absunif_ : {A B} B -> B -> A -> A -> prop.
+absunif : [A B] A -> B -> (B -> A) -> prop.
+absunif_aux, absunif_ : [A B] B -> B -> A -> A -> prop.
 
 absunif_ Unif Replace Root Replace when refl.sameunif Root Unif.
 absunif_ Unif Replace Root Root when refl.isunif Root.

--- a/stdlib/morerefl.makam
+++ b/stdlib/morerefl.makam
@@ -11,9 +11,9 @@ sameunif X Y <-
 %extend userdef.
 
 (* reimplement two builtin predicates just to show that it's possible to do *)
-getunif : A -> B -> prop.
+getunif : {A B} A -> B -> prop.
 
-getunif_aux, getunif_ : option B -> A -> option B -> prop.
+getunif_aux, getunif_ : {A B} option B -> A -> option B -> prop.
 
 getunif_aux X Y Z <- demand.case_otherwise (getunif_ X Y Z) (generic.fold getunif_aux X Y Z).
 getunif_ (some Res) _ (some Res).
@@ -21,8 +21,8 @@ getunif_ _ X (some X) when refl.isunif X.
 
 getunif Root Unif <- getunif_aux none Root (some Unif).
 
-absunif : A -> B -> (B -> A) -> prop.
-absunif_aux, absunif_ : B -> B -> A -> A -> prop.
+absunif : {A B} A -> B -> (B -> A) -> prop.
+absunif_aux, absunif_ : {A B} B -> B -> A -> A -> prop.
 
 absunif_ Unif Replace Root Replace when refl.sameunif Root Unif.
 absunif_ Unif Replace Root Root when refl.isunif Root.

--- a/stdlib/option.makam
+++ b/stdlib/option.makam
@@ -3,16 +3,16 @@ none : option A.
 some : A -> option A.
 
 %extend option.
-map : [A B] (A -> B -> prop) -> option A -> option B -> prop.
+map : (A -> B -> prop) -> option A -> option B -> prop.
 map P (some X) (some Y) <- P X Y.
 map P none none.
 
-issome : [A] option A -> prop.
+issome : option A -> prop.
 issome (some _).
 
-isnone : [A] option A -> prop.
+isnone : option A -> prop.
 isnone none.
 
-get : [A] option A -> A -> prop.
+get : option A -> A -> prop.
 get (some X) X.
 %end.

--- a/stdlib/tuple.makam
+++ b/stdlib/tuple.makam
@@ -1,6 +1,6 @@
 %extend tuple.
 
-map : [A B C D] (A -> C -> prop) -> (B -> D -> prop) -> A * B -> C * D -> prop.
+map : (A -> C -> prop) -> (B -> D -> prop) -> A * B -> C * D -> prop.
 map P Q (X, Y) (X', Y') <- P X X', Q Y Y'.
 
 dynlist : A -> list dyn -> prop.
@@ -9,7 +9,7 @@ dynlist Res [dyn Res]
 dynlist Res (dyn HD :: TL') when not(typ.isunif Res), dyn.eq Res (HD, TL) <-
   dynlist TL TL'.
 
-ofdynlist : list dyn -> A -> prop.
+ofdynlist : {A} list dyn -> A -> prop.
 ofdynlist [dyn Res] Res.
 ofdynlist (dyn HD :: TL) (HD, TL') <- ofdynlist TL TL'.
 

--- a/stdlib/tuple.makam
+++ b/stdlib/tuple.makam
@@ -9,7 +9,7 @@ dynlist Res [dyn Res]
 dynlist Res (dyn HD :: TL') when not(typ.isunif Res), dyn.eq Res (HD, TL) <-
   dynlist TL TL'.
 
-ofdynlist : {A} list dyn -> A -> prop.
+ofdynlist : [A] list dyn -> A -> prop.
 ofdynlist [dyn Res] Res.
 ofdynlist (dyn HD :: TL) (HD, TL') <- ofdynlist TL TL'.
 

--- a/stdlib/typ.makam
+++ b/stdlib/typ.makam
@@ -1,6 +1,6 @@
 %extend typ.
 
-eq : {B} A -> B -> prop.
+eq : [B] A -> B -> prop.
 eq (X : A) (Y : A).
 
 

--- a/stdlib/typ.makam
+++ b/stdlib/typ.makam
@@ -1,6 +1,6 @@
 %extend typ.
 
-eq : A -> B -> prop.
+eq : {B} A -> B -> prop.
 eq (X : A) (Y : A).
 
 

--- a/stdlib/vars.makam
+++ b/stdlib/vars.makam
@@ -5,7 +5,7 @@
 (* freevars *)
 freevars : A -> list B -> prop.
 freevars_aux : list B -> A -> list B -> prop.
-freevars_aux_ : {A} list B -> A -> list B -> prop.
+freevars_aux_ : [A] list B -> A -> list B -> prop.
 freevars_dontadd : A -> prop.
 
 freevars_aux Acc Root Result <-
@@ -25,7 +25,7 @@ freevars Root Result <-
 (* unifvars *)
 unifvars : A -> list B -> prop.
 unifvars_aux : list B -> A -> list B -> prop.
-unifvars_aux_ : {A} list B -> A -> list B -> prop.
+unifvars_aux_ : [A] list B -> A -> list B -> prop.
 
 unifvars_aux Acc Root Result <-
   demand.case_otherwise (unifvars_aux_ Acc Root Result)

--- a/stdlib/vars.makam
+++ b/stdlib/vars.makam
@@ -3,9 +3,9 @@
 
 
 (* freevars *)
-freevars : [A B]A -> list B -> prop.
+freevars : A -> list B -> prop.
 freevars_aux : list B -> A -> list B -> prop.
-freevars_aux_ : list B -> A -> list B -> prop.
+freevars_aux_ : {A} list B -> A -> list B -> prop.
 freevars_dontadd : A -> prop.
 
 freevars_aux Acc Root Result <-
@@ -23,9 +23,9 @@ freevars Root Result <-
 
   
 (* unifvars *)
-unifvars : [A B]A -> list B -> prop.
+unifvars : A -> list B -> prop.
 unifvars_aux : list B -> A -> list B -> prop.
-unifvars_aux_ : list B -> A -> list B -> prop.
+unifvars_aux_ : {A} list B -> A -> list B -> prop.
 
 unifvars_aux Acc Root Result <-
   demand.case_otherwise (unifvars_aux_ Acc Root Result)

--- a/tests/core_expandmeta_subst_rest_of_args.makam
+++ b/tests/core_expandmeta_subst_rest_of_args.makam
@@ -1,14 +1,14 @@
 (* Catch a bug I ran into at some point *)
 
-map : [A B] (A -> B -> prop) -> list A -> list B -> prop.
+map : (A -> B -> prop) -> list A -> list B -> prop.
 map P [] [].
 map P (HD :: TL) (HD' :: TL') <- P HD HD', map P TL TL'.
 
-catenable : [A] list A -> (list A -> list A) -> prop.
+catenable : list A -> (list A -> list A) -> prop.
 catenable [] (fun x => x).
 catenable (HD :: TL) (fun x => HD :: (TL' x)) <- catenable TL TL'.
 
-flatten : [A] list (list A) -> list A -> prop.
+flatten : list (list A) -> list A -> prop.
 flatten LS L <- map catenable LS LS',
                 reverse LS' LS'rev,
                 foldl (fun cur lst => eq (lst cur)) nil LS'rev L.

--- a/tests/stdlib/structural.makam
+++ b/tests/stdlib/structural.makam
@@ -1,5 +1,5 @@
-change : A -> A -> prop.
-change_ : A -> A -> prop.
+change : {A} A -> A -> prop.
+change_ : {A} A -> A -> prop.
 
 change X Y <-
   demand.case_otherwise (change_ X Y)

--- a/tests/stdlib/structural.makam
+++ b/tests/stdlib/structural.makam
@@ -1,5 +1,5 @@
-change : {A} A -> A -> prop.
-change_ : {A} A -> A -> prop.
+change : [A] A -> A -> prop.
+change_ : [A] A -> A -> prop.
 
 change X Y <-
   demand.case_otherwise (change_ X Y)

--- a/tests/use_directives/index.makam
+++ b/tests/use_directives/index.makam
@@ -3,7 +3,7 @@
 test : type.
 test : test.
 
-testprop : A -> prop.
+testprop : {A} A -> prop.
 testprop test.
 
 %import qualified.

--- a/tests/use_directives/index.makam
+++ b/tests/use_directives/index.makam
@@ -3,7 +3,7 @@
 test : type.
 test : test.
 
-testprop : {A} A -> prop.
+testprop : [A] A -> prop.
 testprop test.
 
 %import qualified.


### PR DESCRIPTION
Switches the square bracket notation in types to denote ad-hoc polymorphism, not parametric.

Fixes #5.
