### PR TITLE
literate developments for ICFP17: ML subset

### DIFF
--- a/examples/paper/03-dependent-binding.makam
+++ b/examples/paper/03-dependent-binding.makam
@@ -257,8 +257,8 @@ n-ary tuples require a type for pattern lists:
 pattlist : type -> type -> type.
 patt_tuple : pattlist T T' -> patt T T'.
 
-patt_nil : pattlist T T.
-patt_cons : patt T1 T2 -> pattlist T2 T3 -> pattlist T1 T3.
+nil : pattlist T T.
+cons : patt T1 T2 -> pattlist T2 T3 -> pattlist T1 T3.
 
 (*
 
@@ -294,8 +294,8 @@ typeof :
 typeof (patt_tuple PS) S' S (product TS) :-
   typeof PS S' S TS.
 
-typeof patt_nil S S [].
-typeof (patt_cons P PS) S3 S1 (T :: TS) :-
+typeof [] S S [].
+typeof (P :: PS) S3 S1 (T :: TS) :-
   typeof PS S3 S2 TS, typeof P S2 S1 T.
 
 typeof (case_or_else Scrutinee Pattern Body Else) T' :-
@@ -328,8 +328,8 @@ pattlist_to_termlist : [T T'] pattlist T T' -> list term -> subst term T' -> sub
 patt_to_term (patt_tuple PS) (tuple ES) Subst' Subst :-
   pattlist_to_termlist PS ES Subst' Subst.
 
-pattlist_to_termlist patt_nil [] Subst Subst.
-pattlist_to_termlist (patt_cons P PS) (T :: TS) Subst3 Subst1 <-
+pattlist_to_termlist [] [] Subst Subst.
+pattlist_to_termlist (P :: PS) (T :: TS) Subst3 Subst1 <-
   pattlist_to_termlist PS TS Subst3 Subst2,
   patt_to_term P T Subst2 Subst1.
 

--- a/examples/paper/03-dependent-binding.makam
+++ b/examples/paper/03-dependent-binding.makam
@@ -98,8 +98,8 @@ precise types:
 *)
 
 subst : type -> type -> type.
-snil : subst A unit.
-scons : A -> subst A T -> subst A (A * T).
+nil : subst A unit.
+cons : A -> subst A T -> subst A (A * T).
 
 (*
 
@@ -122,12 +122,12 @@ to resolve ambiguity between overloaded predicates easily.
 
 *)
 
-intromany (dbindbase F) P :- P snil.
+intromany (dbindbase F) P :- P nil.
 intromany (dbindnext F) P :-
-  (x:A -> intromany (F x) (pfun t => P (scons x t))).
+  (x:A -> intromany (F x) (pfun t => P (x :: t))).
 
-applymany (dbindbase Body) snil Body.
-applymany (dbindnext F) (scons X XS) Body :-
+applymany (dbindbase Body) nil Body.
+applymany (dbindnext F) (cons X XS) Body :-
   applymany (F X) XS Body.
 
 openmany F P :-
@@ -141,12 +141,12 @@ Also, we define predicates analogous to `map` and `assumemany` for the
 *)
 
 assumemany : [T T'] (A -> B -> prop) -> subst A T -> subst B T' -> prop -> prop.
-assumemany P snil snil Q :- Q.
-assumemany P (scons X XS) (scons Y YS) Q :- (P X Y -> assumemany P XS YS Q).
+assumemany P [] [] Q :- Q.
+assumemany P (X :: XS) (Y :: YS) Q :- (P X Y -> assumemany P XS YS Q).
 
 map : [T T'] (A -> B -> prop) -> subst A T -> subst B T' -> prop.
-map P snil snil.
-map P (scons X XS) (scons Y YS) :- P X Y, map P XS YS.
+map P [] [].
+map P (X :: XS) (Y :: YS) :- P X Y, map P XS YS.
 
 (*
 
@@ -281,25 +281,25 @@ available, plus the type of the pattern.
 
 typeof : [T T' Ttyp T'typ] patt T T' -> subst typ T'typ -> subst typ Ttyp -> typ -> prop.
 
-typeof patt_var S' (scons T S') T.
+typeof patt_var S' (cons T S') T.
 typeof patt_wild S S T.
 typeof patt_zero S S nat.
 typeof (patt_succ P) S' S nat :-
   typeof P S' S nat.
 
-typeof_pattlist :
+typeof :
   [T T' Ttyp T'typ] pattlist T T' -> subst typ T'typ -> subst typ Ttyp -> list typ -> prop.
 
 typeof (patt_tuple PS) S' S (product TS) :-
-  typeof_pattlist PS S' S TS.
+  typeof PS S' S TS.
 
-typeof_pattlist patt_nil S S [].
-typeof_pattlist (patt_cons P PS) S3 S1 (T :: TS) :-
-  typeof_pattlist PS S3 S2 TS, typeof P S2 S1 T.
+typeof patt_nil S S [].
+typeof (patt_cons P PS) S3 S1 (T :: TS) :-
+  typeof PS S3 S2 TS, typeof P S2 S1 T.
 
 typeof (case_or_else Scrutinee Pattern Body Else) T' :-
   typeof Scrutinee T,
-  typeof Pattern snil TS T,
+  typeof Pattern nil TS T,
   openmany Body (pfun xs body =>
      (assumemany typeof xs TS (typeof body T'))
   ),
@@ -317,7 +317,7 @@ unification with the scrutinee succeeds.
 *)
 
 patt_to_term : [T T'] patt T T' -> term -> subst term T' -> subst term T -> prop.
-patt_to_term patt_var X Subst (scons X Subst).
+patt_to_term patt_var X Subst (cons X Subst).
 patt_to_term patt_wild _ Subst Subst.
 patt_to_term patt_zero zero Subst Subst.
 patt_to_term (patt_succ PN) (succ EN) Subst' Subst :- patt_to_term PN EN Subst' Subst.
@@ -333,7 +333,7 @@ pattlist_to_termlist (patt_cons P PS) (T :: TS) Subst3 Subst1 <-
   patt_to_term P T Subst2 Subst1.
 
 eval (case_or_else Scrutinee Pattern Body Else) V :-
-  patt_to_term Pattern TermWithUnifvars snil Unifvars,
+  patt_to_term Pattern TermWithUnifvars nil Unifvars,
   if (eq Scrutinee TermWithUnifvars)  (* reuse unification from the meta-language *)
   then (applymany Body Unifvars Body', eval Body' V)
   else (eval Else V).

--- a/examples/paper/03-dependent-binding.makam
+++ b/examples/paper/03-dependent-binding.makam
@@ -113,12 +113,14 @@ openmany : [T] dbind A T B -> (subst A T -> B -> prop) -> prop.
 
 (*
 
-Note that we are reusing the same predicate names as before. Makam allows overloading for all
-variable names; expected types are taken into account for resolving variables and disambiguating
-between them, as has been long known to be possible in the bi-directional type-checking
-literature. Type ascription is used when variable resolution is ambiguous.  We also avoid
-overloading for constructors; having unambiguous types for constructors means that they can be used
-to resolve ambiguity between overloaded predicates easily. 
+Note that we are reusing the same predicate names as before. Makam allows overloading for
+all variable names; expected types are taken into account for resolving variables and
+disambiguating between them, as has been long known to be possible in the bi-directional
+type-checking literature. Type ascription is used when variable resolution is
+ambiguous. We also sometimes avoid overloading for constructors; having unambiguous types
+for constructors means that they can be used to resolve ambiguity between overloaded
+predicates easily. However, here we reuse the `nil` and `cons` constructors for `subst`
+so that we can use the sugared form for list-like datatypes (using `[]` and `::`).
 
 *)
 
@@ -126,9 +128,8 @@ intromany (dbindbase F) P :- P nil.
 intromany (dbindnext F) P :-
   (x:A -> intromany (F x) (pfun t => P (x :: t))).
 
-applymany (dbindbase Body) nil Body.
-applymany (dbindnext F) (cons X XS) Body :-
-  applymany (F X) XS Body.
+applymany (dbindbase Body) [] Body.
+applymany (dbindnext F) (X :: XS) Body :- applymany (F X) XS Body.
 
 openmany F P :-
   intromany F (pfun xs => [Body] applymany F xs Body, P xs Body).
@@ -317,7 +318,7 @@ unification with the scrutinee succeeds.
 *)
 
 patt_to_term : [T T'] patt T T' -> term -> subst term T' -> subst term T -> prop.
-patt_to_term patt_var X Subst (cons X Subst).
+patt_to_term patt_var X Subst (X :: Subst).
 patt_to_term patt_wild _ Subst Subst.
 patt_to_term patt_zero zero Subst Subst.
 patt_to_term (patt_succ PN) (succ EN) Subst' Subst :- patt_to_term PN EN Subst' Subst.
@@ -333,7 +334,7 @@ pattlist_to_termlist (patt_cons P PS) (T :: TS) Subst3 Subst1 <-
   patt_to_term P T Subst2 Subst1.
 
 eval (case_or_else Scrutinee Pattern Body Else) V :-
-  patt_to_term Pattern TermWithUnifvars nil Unifvars,
+  patt_to_term Pattern TermWithUnifvars [] Unifvars,
   if (eq Scrutinee TermWithUnifvars)  (* reuse unification from the meta-language *)
   then (applymany Body Unifvars Body', eval Body' V)
   else (eval Else V).

--- a/examples/paper/03-dependent-binding.md
+++ b/examples/paper/03-dependent-binding.md
@@ -223,8 +223,8 @@ n-ary tuples require a type for pattern lists:
 pattlist : type -> type -> type.
 patt_tuple : pattlist T T' -> patt T T'.
 
-patt_nil : pattlist T T.
-patt_cons : patt T1 T2 -> pattlist T2 T3 -> pattlist T1 T3.
+nil : pattlist T T.
+cons : patt T1 T2 -> pattlist T2 T3 -> pattlist T1 T3.
 ```
 
 We can now encode a single-branch "case-or-else" statement as follows:
@@ -256,8 +256,8 @@ typeof :
 typeof (patt_tuple PS) S' S (product TS) :-
   typeof PS S' S TS.
 
-typeof patt_nil S S [].
-typeof (patt_cons P PS) S3 S1 (T :: TS) :-
+typeof [] S S [].
+typeof (P :: PS) S3 S1 (T :: TS) :-
   typeof PS S3 S2 TS, typeof P S2 S1 T.
 
 typeof (case_or_else Scrutinee Pattern Body Else) T' :-
@@ -288,8 +288,8 @@ pattlist_to_termlist : [T T'] pattlist T T' -> list term -> subst term T' -> sub
 patt_to_term (patt_tuple PS) (tuple ES) Subst' Subst :-
   pattlist_to_termlist PS ES Subst' Subst.
 
-pattlist_to_termlist patt_nil [] Subst Subst.
-pattlist_to_termlist (patt_cons P PS) (T :: TS) Subst3 Subst1 <-
+pattlist_to_termlist [] [] Subst Subst.
+pattlist_to_termlist (P :: PS) (T :: TS) Subst3 Subst1 <-
   pattlist_to_termlist PS TS Subst3 Subst2,
   patt_to_term P T Subst2 Subst1.
 

--- a/examples/paper/03-dependent-binding.md
+++ b/examples/paper/03-dependent-binding.md
@@ -98,21 +98,22 @@ applymany : [T] dbind A T B -> subst A T -> B -> prop.
 openmany : [T] dbind A T B -> (subst A T -> B -> prop) -> prop.
 ```
 
-Note that we are reusing the same predicate names as before. Makam allows overloading for all
-variable names; expected types are taken into account for resolving variables and disambiguating
-between them, as has been long known to be possible in the bi-directional type-checking
-literature. Type ascription is used when variable resolution is ambiguous.  We also avoid
-overloading for constructors; having unambiguous types for constructors means that they can be used
-to resolve ambiguity between overloaded predicates easily. 
+Note that we are reusing the same predicate names as before. Makam allows overloading for
+all variable names; expected types are taken into account for resolving variables and
+disambiguating between them, as has been long known to be possible in the bi-directional
+type-checking literature. Type ascription is used when variable resolution is
+ambiguous. We also sometimes avoid overloading for constructors; having unambiguous types
+for constructors means that they can be used to resolve ambiguity between overloaded
+predicates easily. However, here we reuse the `nil` and `cons` constructors for `subst`
+so that we can use the sugared form for list-like datatypes (using `[]` and `::`).
 
 ```makam
 intromany (dbindbase F) P :- P nil.
 intromany (dbindnext F) P :-
   (x:A -> intromany (F x) (pfun t => P (x :: t))).
 
-applymany (dbindbase Body) nil Body.
-applymany (dbindnext F) (cons X XS) Body :-
-  applymany (F X) XS Body.
+applymany (dbindbase Body) [] Body.
+applymany (dbindnext F) (X :: XS) Body :- applymany (F X) XS Body.
 
 openmany F P :-
   intromany F (pfun xs => [Body] applymany F xs Body, P xs Body).
@@ -277,7 +278,7 @@ unification with the scrutinee succeeds.
 
 ```makam
 patt_to_term : [T T'] patt T T' -> term -> subst term T' -> subst term T -> prop.
-patt_to_term patt_var X Subst (cons X Subst).
+patt_to_term patt_var X Subst (X :: Subst).
 patt_to_term patt_wild _ Subst Subst.
 patt_to_term patt_zero zero Subst Subst.
 patt_to_term (patt_succ PN) (succ EN) Subst' Subst :- patt_to_term PN EN Subst' Subst.
@@ -293,7 +294,7 @@ pattlist_to_termlist (patt_cons P PS) (T :: TS) Subst3 Subst1 <-
   patt_to_term P T Subst2 Subst1.
 
 eval (case_or_else Scrutinee Pattern Body Else) V :-
-  patt_to_term Pattern TermWithUnifvars nil Unifvars,
+  patt_to_term Pattern TermWithUnifvars [] Unifvars,
   if (eq Scrutinee TermWithUnifvars)  (* reuse unification from the meta-language *)
   then (applymany Body Unifvars Body', eval Body' V)
   else (eval Else V).

--- a/examples/paper/04-ml-subset.makam
+++ b/examples/paper/04-ml-subset.makam
@@ -256,6 +256,7 @@ Example:
     (main (constr lcons [zero, constr lnil []]))
 
     )))))),
+
  wfprogram _PROGRAM,
  eval _PROGRAM FINAL) ?
 

--- a/examples/paper/04-ml-subset.makam
+++ b/examples/paper/04-ml-subset.makam
@@ -8,12 +8,12 @@
 Let us now proceed to encode more features of a programming language like ML using the
 techniques we have seen so far.
 
-First, let's add polymorphism, therefore extending our simply typed lambda calculus to
-System F. We will only consider the explicit polymorphism case for the time being, and
-explore type inference later.
+First, let's add polymorphism, therefore extending our simply typed lambda calculus to System
+F. We will only consider the explicit polymorphism case for the time being, and explore type
+inference later.
 
-We need a type for quantification over types, as well as term-level constructs for
-functions over types and instantiating a polymorphic function with a specific type.
+We need a type for quantification over types, as well as term-level constructs for functions
+over types and instantiating a polymorphic function with a specific type.
 
 *)
 
@@ -35,15 +35,14 @@ typeof (appt E T) (TF T) :-
 
 (*
 
-One thing to note is that in a pen-and-paper version we would need to define a new
-context that keeps track of type variables that are in scope (typically named
-$\Delta$), and an auxiliary judgement of the form $\Delta \vdash \tau \text{wf}$ that
-checks that all type variables used in $\tau$ are in scope. Here we get type
-well-formedness for free. Furthermore, if we had to keep track of further information
-about type variables (e.g. their kind), we could have added an assumption of the form
-`kindof a K ->`. Since the local assumption context can carry rules for any predicate,
-no extra declaration or change to the existing rules would be needed, as would be
-required in the pen-and-paper version in order to incorporate the new $\Delta$
+One thing to note is that in a pen-and-paper version we would need to define a new context that
+keeps track of type variables that are in scope (typically named $\Delta$), and an auxiliary
+judgement of the form $\Delta \vdash \tau \text{wf}$ that checks that all type variables used
+in $\tau$ are in scope. Here we get type well-formedness for free. Furthermore, if we had to
+keep track of further information about type variables (e.g. their kind), we could have added
+an assumption of the form `kindof a K ->`. Since the local assumption context can carry rules
+for any predicate, no extra declaration or change to the existing rules would be needed, as
+would be required in the pen-and-paper version in order to incorporate the new $\Delta$
 context.
 
 With these additions, we can give a polymorphic type to the identity function:
@@ -54,10 +53,10 @@ typeof (lamt (fun a => lam a (fun x => x))) T ?
 
 (*
 
-Moving on towards a more ML-like language, we would like to add the option to declare
-algebraic datatypes. This requires us to first introduce a notion of top-level
-programs, composed of a series of declarations of types and terms, as well as 
-a predicate to check that a program is well-formed:
+Moving on towards a more ML-like language, we would like to add the option to declare algebraic
+datatypes. This requires us to first introduce a notion of top-level programs, composed of a
+series of declarations of types and terms, as well as a predicate to check that a program is
+well-formed:
 
 *)
 
@@ -66,8 +65,8 @@ wfprogram : program -> prop.
 
 (*
 
-Let us add `let` definitions as a first example of a program component. These introduce
-a term variable that can be used in the rest of the program:
+Let us add `let` definitions as a first example of a program component. These introduce a term
+variable that can be used in the rest of the program:
 
 *)
 
@@ -79,8 +78,8 @@ wfprogram (let E P) :-
 
 (*
 
-We also need a "last" component for the program -- typically this takes the form of
-a main expression:
+We also need a "last" component for the program -- typically this takes the form of a main
+expression:
 
 *)
 
@@ -91,9 +90,8 @@ wfprogram (main E) :-
 
 (*
 
-Let us now proceed to algebraic datatypes. Datatypes have a name, a number of type
-parameters, and a list of constructors; constructors themselves have a name and a list
-of arguments:
+Let us now proceed to algebraic datatypes. Datatypes have a name, a number of type parameters,
+and a list of constructors; constructors themselves have a name and a list of arguments:
 
 *)
 
@@ -101,50 +99,110 @@ typeconstructor : type -> type.
 constructor : type.
 
 constructor_declaration : type -> type.
-cdnil : constructor_declaration unit.
-cdcons : list typ -> constructor_declaration T -> constructor_declaration (constructor * T).
+nil : constructor_declaration unit.
+cons : list typ -> constructor_declaration T -> constructor_declaration (constructor * T).
+datatype_declaration : type -> type -> type.
+datatype_declaration : 
+  (typeconstructor Arity -> dbind typ Arity (constructor_declaration Constructors)) ->
+  datatype_declaration Arity Constructors.
 
-datatype_declaration :
-  (typeconstructor T -> dbind typ T (constructor_declaration C)) ->
-  (typeconstructor T -> dbind constructor C program) ->
+datatype :
+  datatype_declaration Arity Constructors ->
+  (typeconstructor Arity -> dbind constructor Constructors program) ->
   program.
 
 (*
 
-Adding the necessary predicates:
+The datatype introduces a type constructor, as well as a number of constructors in the rest of
+the program. Here we use dependency to carry the arity of the type constructor in its
+meta-level type, avoiding the need for a well-formedness predicate for types. Of course, in
+situations where object-level types are more complicated, we would need to incorporate kind
+checking into our predicates.
+
+Let us now proceed to well-formedness for datatype declarations. We will need two auxiliary
+predicates: one that keeps information about a constructor -- which type it belongs to, what
+arguments it expects; and another one that "introduces" constructors into the rest of the
+program -- similar to the `intromany` predicate we have seen before.
 
 *)
 
-argumentsof : constructor -> typeconstructor T -> dbind typ T (list typ) -> prop.
+constructor_info :
+  constructor -> typeconstructor Arity -> dbind typ Arity (list typ) -> prop.
 
-open_constructors : [T C]
-  typeconstructor T -> subst typ T -> constructor_declaration C -> (subst constructor C -> prop) -> prop.
-open_constructors _ _ cdnil P :- P [].
-open_constructors TC TVars (cdcons ConstructorType CS) P :-
-  applymany PolyC TVars ConstructorType,
+intro_constructors : [Arity Constructors]
+  typeconstructor Arity -> subst typ Arity ->
+  constructor_declaration Constructors -> (subst constructor Constructors -> prop) -> prop.
+
+intro_constructors _ _ [] P :- P [].
+intro_constructors TypConstr TypVars (ConstructorType :: Constructors) P :-
+  applymany PolyType TypVars ConstructorType,
   (c:constructor ->
-   argumentsof c TC PolyC -> open_constructors TC Subst CS (pfun cs => P (c :: cs))).
+   constructor_info c TypConstr PolyType ->
+   intro_constructors TypConstr TypVars Constructors (pfun cs => P (c :: cs))).
 
-wfprogram (datatype_declaration Constructors Rest) :-
+(*
+
+One interesting part in this one is the `applymany`: this is used in the opposite direction
+than what we have used it so far, getting `TypVars` and `ConstructorType` as inputs, and
+producing `PolyType` as an output. This is done so that we abstract over the type variables
+used in the datatype declaration, creating a polymorphic type for the type of the constructor,
+that can be instantiated with different types at different places.
+
+*)
+
+wfprogram (datatype (datatype_declaration ConstructorDecls) Rest) :-
   (dt:(typeconstructor T) ->
-    openmany (Constructors dt) (pfun tvars constructor_decls =>
-      open_constructors dt tvars constructor_decls (pfun constructors => ([Program']
+    openmany (ConstructorDecls dt) (pfun tvars constructor_decls => 
+      intro_constructors dt tvars constructor_decls (pfun constructors => ([Program']
         applymany (Rest dt) constructors Program',
         wfprogram Program')))).
 
 (*
 
-Let's add term- and type-level formers:
+In order to be able to refer to datatypes and constructors, we will need type- and term-level
+formers.
 
 *)
 
-tc : typeconstructor T -> subst typ T -> typ.
-c : constructor -> subst typ T -> list term -> term.
+tconstr : typeconstructor T -> subst typ T -> typ.
+constr : constructor -> list term -> term.
 
-typeof (c Constructor TypArgs Args) (tc TC TypArgs) :-
-  argumentsof Constructor TC PolyC,
-  applymany PolyC TypArgs Typs,
+typeof (constr Constructor Args) (tconstr TypConstr TypArgs) :-
+  constructor_info Constructor TypConstr PolyType,
+  applymany PolyType TypArgs Typs,
   map typeof Args Typs.
+
+(*
+
+We will also need pattern matching:
+
+*)
+
+patt_constr : constructor -> pattlist T T' -> patt T T'.
+
+typeof (patt_constr Constructor Args) S' S (tconstr TypConstr TypArgs) :-
+  constructor_info Constructor TypConstr PolyType,
+  applymany PolyType TypArgs Typs,
+  typeof Args S' S Typs.
+
+(*
+
+As an example, we will define lists, and the append function for them:
+
+*)
+
+%debug+.
+wfprogram
+
+  (datatype
+    (datatype_declaration (fun llist => dbindnext (fun a => dbindbase (
+    [ [] (* nil *) ,
+      [a, tconstr llist [a]] (* cons of a * list a *) ]))))
+  (fun llist => dbindnext (fun lnil => dbindnext (fun lcons => dbindbase (
+
+  (main (constr lcons [zero, constr lnil []]))
+  
+))))) ?
 
 (*
 *)

--- a/examples/paper/04-ml-subset.makam
+++ b/examples/paper/04-ml-subset.makam
@@ -1,0 +1,184 @@
+(*
+*)
+
+%use "03-dependent-binding".
+
+(*
+
+Let us now proceed to encode more features of a programming language like ML using the
+techniques we have seen so far.
+
+First, let's add polymorphism, therefore extending our simply typed lambda calculus to
+System F. We will only consider the explicit polymorphism case for the time being, and
+explore type inference later.
+
+We need a type for quantification over types, as well as term-level constructs for
+functions over types and instantiating a polymorphic function with a specific type.
+
+*)
+
+forall : (typ -> typ) -> typ.
+lamt : (typ -> term) -> term.
+appt : term -> typ -> term.
+
+(*
+
+The typing rules are similarly straightforward.
+
+*)
+
+typeof (lamt E) (forall T) :-
+  (a:typ -> typeof (E a) (T a)).
+
+typeof (appt E T) (TF T) :-
+  typeof E (forall TF).
+
+(*
+
+One thing to note is that in a pen-and-paper version we would need to define a new
+context that keeps track of type variables that are in scope (typically named
+$\Delta$), and an auxiliary judgement of the form $\Delta \vdash \tau \text{wf}$ that
+checks that all type variables used in $\tau$ are in scope. Here we get type
+well-formedness for free. Furthermore, if we had to keep track of further information
+about type variables (e.g. their kind), we could have added an assumption of the form
+`kindof a K ->`. Since the local assumption context can carry rules for any predicate,
+no extra declaration or change to the existing rules would be needed, as would be
+required in the pen-and-paper version in order to incorporate the new $\Delta$
+context.
+
+With these additions, we can give a polymorphic type to the identity function:
+
+*)
+
+typeof (lamt (fun a => lam a (fun x => x))) T ?
+
+(*
+
+Moving on towards a more ML-like language, we would like to add the option to declare
+algebraic datatypes. This requires us to first introduce a notion of top-level
+programs, composed of a series of declarations of types and terms, as well as 
+a predicate to check that a program is well-formed. In keeping with an
+ML-like language, we could do something more general than that: add ML-style modules.
+We will need to introduce the ability to create module structures and signatures --
+corresponding to the implementation and specification parts of modules. Structures
+are composed of a series of declarations, while signatures are composed of a series
+of specifications. Therefore:
+
+*)
+
+declaration, specification : type.
+struct, sig : type.
+
+struct : list declaration -> struct.
+sig : list specification -> sig.
+
+(*
+
+`let` definitions are our first example of a module component:
+
+*)
+
+let : string -> term -> declaration.
+val : string -> typ -> specification.
+
+(*
+
+One thing to note is the presence of strings: as opposed to what we've seen so far,
+we'll be using concrete strings in the different components of structures and
+signatures, as opposed to abstract binders through higher-order abstract syntax. The
+reason for this is two-fold: first, matching components between a structure and a
+signature is done based on their concrete names; and second, there is not really a
+case where we would need substitution for the abstract variables, have we used those
+instead. As a result, we do not have to use a higher-order representation for the
+variables used in modules, and we can go with a normal first-class representation
+instead.
+
+The typing rule of a `let` declaration should make sure that the term matches the type
+of the corresponding `val` specification, and also that the corresponding named
+variable gets the right type in the rest of the module. In order to be able to capture
+the latter part, we will use a list of propositions, representing local assumptions
+that should be made in the rest of the module. We will also need a term constructor
+for named variables:
+
+*)
+
+named : string -> term.
+specof : declaration -> specification -> list prop -> prop.
+specof (let S E) (val S T) [typeof (named S) T] :-
+  typeof E T.
+
+(*
+
+Let us now move on to datatypes. Datatypes have a name, a number of type parameters,
+and a list of constructors; constructors themselves have a name and a list of
+arguments. We will only allow transparent datatypes for now, whose specification
+matches their declaration.
+
+*)
+
+datatype_decl, constructor_decl : type.
+datatype_decl : string -> dbind typ T (list constructor) -> datatype_decl.
+constructor_decl : string -> subst typ T' -> constructor_decl.
+struct_datatype : datatype_decl -> declaration.
+sig_datatype : datatype_decl -> specification.
+
+(*
+
+We will also need type- and term-level constructs for referring to a datatype and
+a constructor, respectively:
+
+*)
+
+d : string -> subst typ T -> typ.
+c : string -> subst term T -> term.
+
+(*
+
+Typing:
+
+*)
+
+datatype : datatype_decl -> prop.
+
+wftype : typ -> prop.
+wftype (d S Args) :-
+  datatype (datatype_decl S Decl),
+  intromany Decl (pfun typevars =>
+    map (pfun var arg => wftype arg) typevars Args
+  ).
+
+(*
+
+specof (struct_datatype Datatype) (sig_datatype Datatype)
+       ((datatype DataType) : ConstructorAssumptions) :-
+  eq Datatype (datatype_decl TypeName Declaration),
+  (datatype (datatype_decl TypeName Declaration) ->
+    wf_constructors
+
+
+We will also need predicates that relate definitions to specifications, and structures
+to signatures. (We will focus on principal signatures for the time being, 
+
+*)
+
+specof : string -> declaration -> specification -> list prop -> type.
+sigof : struct -> sig -> type.
+
+(*
+
+*)
+
+sigof (struct S) (sig SI) :-
+  principal_sigof S SI',
+  sigmatch SI' SI.
+
+principal_sigof (struct []) [].
+principal_sigof ((S, Decl) :: Decls) ((S, Spec) :: Specs) :-
+  principal_sigof S Decl Spec Assumptions,
+  assumemany Assumptions (sigof Decls Specs).
+  
+
+We need a predicate that relates definitions to specifications:
+
+*)
+

--- a/examples/paper/04-ml-subset.makam
+++ b/examples/paper/04-ml-subset.makam
@@ -144,7 +144,7 @@ c : constructor -> subst typ T -> list term -> term.
 typeof (c Constructor TypArgs Args) (tc TC TypArgs) :-
   argumentsof Constructor TC PolyC,
   applymany PolyC TypArgs Typs,
-  ((map : A -> list B -> list C -> prop) typeof Args Typs).
+  map typeof Args Typs.
 
 (*
 *)

--- a/examples/paper/04-ml-subset.makam
+++ b/examples/paper/04-ml-subset.makam
@@ -136,9 +136,7 @@ constructor_polytypes : [Arity Constructors PolyTypes]
 
 constructor_polytypes _ [] [].
 constructor_polytypes TypVars (ConstructorType :: Constructors) (PolyType :: PolyTypes) :-
-  print_string "abstracting: ", print ConstructorType,
   applymany PolyType TypVars ConstructorType,
-  print_string "abstracted: ", print PolyType,
   constructor_polytypes TypVars Constructors PolyTypes.
 
 (*
@@ -153,11 +151,10 @@ cannot capture the `TypVars` variables:
 wfprogram (datatype (datatype_declaration ConstructorDecls) Program') :-
   (dt:(typeconstructor T) -> ([PolyTypes]
     openmany (ConstructorDecls dt) (pfun tvars constructor_decls => (
-      constructor_polytypes tvars constructor_decls PolyTypes)))),
-  (dt:(typeconstructor T) ->
+      constructor_polytypes tvars constructor_decls PolyTypes)),
     openmany (Program' dt) (pfun constructors program' =>
       assumemany (constructor_info dt) constructors PolyTypes
-      (wfprogram program'))).
+      (wfprogram program')))).
 
 (*
 
@@ -176,7 +173,7 @@ typeof (constr Constructor Args) (tconstr TypConstr TypArgs) :-
 
 (*
 
-We will also need pattern matching:
+We will also need patterns:
 
 *)
 
@@ -204,17 +201,63 @@ wfprogram
   (main
     (letrec
       (dbindnext (fun append => dbindbase (
-      [ lamt (fun a => lam (tconstr llist [a]) (fun l1 => lam #_ (fun l2 =>
+      [ lamt (fun a => lam (tconstr llist [a]) (fun l1 => lam _ (fun l2 =>
         case_or_else l1
           (patt_constr lcons [patt_var, patt_var])
             (dbindnext (fun hd => dbindnext (fun tl => dbindbase (
-            constr lcons [hd, app (app (appt append #_) tl) l2]))))
+            constr lcons [hd, app (app (appt append _) tl) l2]))))
           l2))) ])))
       (dbindnext (fun append => dbindbase (
 
-    (app (app (appt append #_) (constr lcons [zero, constr lnil []])) (constr lcons [zero, constr lnil []]))
+    (app (app (appt append _) (constr lcons [zero, constr lnil []])) (constr lcons [zero, constr lnil []]))
   
 )))))))))) ?
+
+(*
+
+The semantics, if needed:
+*)
+
+patt_to_term (patt_constr Constructor Args) (constr Constructor Args') S' S :-
+  pattlist_to_termlist Args Args' S' S.
+
+eval (constr C Args) (constr C Args') :-
+  map eval Args Args'.
+
+eval : program -> program -> prop.
+
+eval (let E P') P'' :-
+  eval E V, eval (P' V) P''.
+
+eval (datatype D P') (datatype D P'') :-
+  (dt:(typeconstructor T) ->
+    intromany CS (pfun cs => ([P'c P''c]
+    applymany (P' dt) cs P'c,
+    applymany (P'' dt) cs P''c,
+    eval P'c P''c))).
+
+eval (main E) (main V) :-
+  eval E V.
+
+(*
+
+Example:
+
+*)
+
+(eq _PROGRAM (
+
+    (datatype
+      (datatype_declaration (fun llist => dbindnext (fun a => dbindbase (
+      [ [] (* nil *) ,
+        [a, tconstr llist [a]] (* cons of a * list a *) ]))))
+      (fun llist => dbindnext (fun lnil => dbindnext (fun lcons => dbindbase (
+
+    (main (constr lcons [zero, constr lnil []]))
+
+    )))))),
+ wfprogram _PROGRAM,
+ eval _PROGRAM FINAL) ?
 
 (*
 *)

--- a/examples/paper/04-ml-subset.makam
+++ b/examples/paper/04-ml-subset.makam
@@ -119,11 +119,11 @@ argumentsof : constructor -> typeconstructor T -> dbind typ T (list typ) -> prop
 
 open_constructors : [T C]
   typeconstructor T -> subst typ T -> constructor_declaration C -> (subst constructor C -> prop) -> prop.
-open_constructors _ _ cdnil P :- P snil.
+open_constructors _ _ cdnil P :- P [].
 open_constructors TC TVars (cdcons ConstructorType CS) P :-
   applymany PolyC TVars ConstructorType,
   (c:constructor ->
-   argumentsof c TC PolyC -> open_constructors TC Subst CS (pfun cs => P (scons c cs))).
+   argumentsof c TC PolyC -> open_constructors TC Subst CS (pfun cs => P (c :: cs))).
 
 wfprogram (datatype_declaration Constructors Rest) :-
   (dt:(typeconstructor T) ->

--- a/examples/paper/04-ml-subset.makam
+++ b/examples/paper/04-ml-subset.makam
@@ -121,41 +121,43 @@ checking into our predicates.
 
 Let us now proceed to well-formedness for datatype declarations. We will need two auxiliary
 predicates: one that keeps information about a constructor -- which type it belongs to, what
-arguments it expects; and another one that "introduces" constructors into the rest of the
-program -- similar to the `intromany` predicate we have seen before.
-
-*)
-
-constructor_info :
-  constructor -> typeconstructor Arity -> dbind typ Arity (list typ) -> prop.
-
-intro_constructors : [Arity Constructors]
-  typeconstructor Arity -> subst typ Arity ->
-  constructor_declaration Constructors -> (subst constructor Constructors -> prop) -> prop.
-
-intro_constructors _ _ [] P :- P [].
-intro_constructors TypConstr TypVars (ConstructorType :: Constructors) P :-
-  applymany PolyType TypVars ConstructorType,
-  (c:constructor ->
-   constructor_info c TypConstr PolyType ->
-   intro_constructors TypConstr TypVars Constructors (pfun cs => P (c :: cs))).
-
-(*
-
-One interesting part in this one is the `applymany`: this is used in the opposite direction
-than what we have used it so far, getting `TypVars` and `ConstructorType` as inputs, and
-producing `PolyType` as an output. This is done so that we abstract over the type variables
+arguments it expects; and another one that abstracts over the type variables
 used in the datatype declaration, creating a polymorphic type for the type of the constructor,
 that can be instantiated with different types at different places.
 
 *)
 
-wfprogram (datatype (datatype_declaration ConstructorDecls) Rest) :-
+constructor_info :
+  typeconstructor Arity -> constructor -> dbind typ Arity (list typ) -> prop.
+
+constructor_polytypes : [Arity Constructors PolyTypes]
+  subst typ Arity ->
+  constructor_declaration Constructors -> subst (dbind typ Arity (list typ)) PolyTypes -> prop.
+
+constructor_polytypes _ [] [].
+constructor_polytypes TypVars (ConstructorType :: Constructors) (PolyType :: PolyTypes) :-
+  print_string "abstracting: ", print ConstructorType,
+  applymany PolyType TypVars ConstructorType,
+  print_string "abstracted: ", print PolyType,
+  constructor_polytypes TypVars Constructors PolyTypes.
+
+(*
+
+One interesting part in this one is the two `applymany` calls: these are used in the opposite
+direction than what we have used it so far, getting `TypVars` and `ConstructorType` as inputs,
+and producing `PolyType` as an output. We need to be careful though to make sure that `PolyType`
+cannot capture the `TypVars` variables:
+
+*)
+
+wfprogram (datatype (datatype_declaration ConstructorDecls) Program') :-
+  (dt:(typeconstructor T) -> ([PolyTypes]
+    openmany (ConstructorDecls dt) (pfun tvars constructor_decls => (
+      constructor_polytypes tvars constructor_decls PolyTypes)))),
   (dt:(typeconstructor T) ->
-    openmany (ConstructorDecls dt) (pfun tvars constructor_decls => 
-      intro_constructors dt tvars constructor_decls (pfun constructors => ([Program']
-        applymany (Rest dt) constructors Program',
-        wfprogram Program')))).
+    openmany (Program' dt) (pfun constructors program' =>
+      assumemany (constructor_info dt) constructors PolyTypes
+      (wfprogram program'))).
 
 (*
 
@@ -168,7 +170,7 @@ tconstr : typeconstructor T -> subst typ T -> typ.
 constr : constructor -> list term -> term.
 
 typeof (constr Constructor Args) (tconstr TypConstr TypArgs) :-
-  constructor_info Constructor TypConstr PolyType,
+  constructor_info TypConstr Constructor PolyType,
   applymany PolyType TypArgs Typs,
   map typeof Args Typs.
 
@@ -181,7 +183,7 @@ We will also need pattern matching:
 patt_constr : constructor -> pattlist T T' -> patt T T'.
 
 typeof (patt_constr Constructor Args) S' S (tconstr TypConstr TypArgs) :-
-  constructor_info Constructor TypConstr PolyType,
+  constructor_info TypConstr Constructor PolyType,
   applymany PolyType TypArgs Typs,
   typeof Args S' S Typs.
 
@@ -191,7 +193,6 @@ As an example, we will define lists, and the append function for them:
 
 *)
 
-%debug+.
 wfprogram
 
   (datatype
@@ -200,9 +201,20 @@ wfprogram
       [a, tconstr llist [a]] (* cons of a * list a *) ]))))
   (fun llist => dbindnext (fun lnil => dbindnext (fun lcons => dbindbase (
 
-  (main (constr lcons [zero, constr lnil []]))
+  (main
+    (letrec
+      (dbindnext (fun append => dbindbase (
+      [ lamt (fun a => lam (tconstr llist [a]) (fun l1 => lam #_ (fun l2 =>
+        case_or_else l1
+          (patt_constr lcons [patt_var, patt_var])
+            (dbindnext (fun hd => dbindnext (fun tl => dbindbase (
+            constr lcons [hd, app (app (appt append #_) tl) l2]))))
+          l2))) ])))
+      (dbindnext (fun append => dbindbase (
+
+    (app (app (appt append #_) (constr lcons [zero, constr lnil []])) (constr lcons [zero, constr lnil []]))
   
-))))) ?
+)))))))))) ?
 
 (*
 *)

--- a/examples/paper/04-ml-subset.makam
+++ b/examples/paper/04-ml-subset.makam
@@ -57,128 +57,94 @@ typeof (lamt (fun a => lam a (fun x => x))) T ?
 Moving on towards a more ML-like language, we would like to add the option to declare
 algebraic datatypes. This requires us to first introduce a notion of top-level
 programs, composed of a series of declarations of types and terms, as well as 
-a predicate to check that a program is well-formed. In keeping with an
-ML-like language, we could do something more general than that: add ML-style modules.
-We will need to introduce the ability to create module structures and signatures --
-corresponding to the implementation and specification parts of modules. Structures
-are composed of a series of declarations, while signatures are composed of a series
-of specifications. Therefore:
+a predicate to check that a program is well-formed:
 
 *)
 
-declaration, specification : type.
-struct, sig : type.
-
-struct : list declaration -> struct.
-sig : list specification -> sig.
+program : type.
+wfprogram : program -> prop.
 
 (*
 
-`let` definitions are our first example of a module component:
+Let us add `let` definitions as a first example of a program component. These introduce
+a term variable that can be used in the rest of the program:
 
 *)
 
-let : string -> term -> declaration.
-val : string -> typ -> specification.
+let : term -> (term -> program) -> program.
+
+wfprogram (let E P) :-
+  typeof E T,
+  (x:term -> typeof x T -> wfprogram (P x)).
 
 (*
 
-One thing to note is the presence of strings: as opposed to what we've seen so far,
-we'll be using concrete strings in the different components of structures and
-signatures, as opposed to abstract binders through higher-order abstract syntax. The
-reason for this is two-fold: first, matching components between a structure and a
-signature is done based on their concrete names; and second, there is not really a
-case where we would need substitution for the abstract variables, have we used those
-instead. As a result, we do not have to use a higher-order representation for the
-variables used in modules, and we can go with a normal first-class representation
-instead.
-
-The typing rule of a `let` declaration should make sure that the term matches the type
-of the corresponding `val` specification, and also that the corresponding named
-variable gets the right type in the rest of the module. In order to be able to capture
-the latter part, we will use a list of propositions, representing local assumptions
-that should be made in the rest of the module. We will also need a term constructor
-for named variables:
+We also need a "last" component for the program -- typically this takes the form of
+a main expression:
 
 *)
 
-named : string -> term.
-specof : declaration -> specification -> list prop -> prop.
-specof (let S E) (val S T) [typeof (named S) T] :-
-  typeof E T.
+main : term -> program.
+
+wfprogram (main E) :-
+  typeof E _.
 
 (*
 
-Let us now move on to datatypes. Datatypes have a name, a number of type parameters,
-and a list of constructors; constructors themselves have a name and a list of
-arguments. We will only allow transparent datatypes for now, whose specification
-matches their declaration.
+Let us now proceed to algebraic datatypes. Datatypes have a name, a number of type
+parameters, and a list of constructors; constructors themselves have a name and a list
+of arguments:
 
 *)
 
-datatype_decl, constructor_decl : type.
-datatype_decl : string -> dbind typ T (list constructor) -> datatype_decl.
-constructor_decl : string -> subst typ T' -> constructor_decl.
-struct_datatype : datatype_decl -> declaration.
-sig_datatype : datatype_decl -> specification.
+typeconstructor : type -> type.
+constructor : type.
+
+constructor_declaration : type -> type.
+cdnil : constructor_declaration unit.
+cdcons : list typ -> constructor_declaration T -> constructor_declaration (constructor * T).
+
+datatype_declaration :
+  (typeconstructor T -> dbind typ T (constructor_declaration C)) ->
+  (typeconstructor T -> dbind constructor C program) ->
+  program.
 
 (*
 
-We will also need type- and term-level constructs for referring to a datatype and
-a constructor, respectively:
+Adding the necessary predicates:
 
 *)
 
-d : string -> subst typ T -> typ.
-c : string -> subst term T -> term.
+argumentsof : constructor -> typeconstructor T -> dbind typ T (list typ) -> prop.
+
+open_constructors : [T C]
+  typeconstructor T -> subst typ T -> constructor_declaration C -> (subst constructor C -> prop) -> prop.
+open_constructors _ _ cdnil P :- P snil.
+open_constructors TC TVars (cdcons ConstructorType CS) P :-
+  applymany PolyC TVars ConstructorType,
+  (c:constructor ->
+   argumentsof c TC PolyC -> open_constructors TC Subst CS (pfun cs => P (scons c cs))).
+
+wfprogram (datatype_declaration Constructors Rest) :-
+  (dt:(typeconstructor T) ->
+    openmany (Constructors dt) (pfun tvars constructor_decls =>
+      open_constructors dt tvars constructor_decls (pfun constructors => ([Program']
+        applymany (Rest dt) constructors Program',
+        wfprogram Program')))).
 
 (*
 
-Typing:
+Let's add term- and type-level formers:
 
 *)
 
-datatype : datatype_decl -> prop.
+tc : typeconstructor T -> subst typ T -> typ.
+c : constructor -> subst typ T -> list term -> term.
 
-wftype : typ -> prop.
-wftype (d S Args) :-
-  datatype (datatype_decl S Decl),
-  intromany Decl (pfun typevars =>
-    map (pfun var arg => wftype arg) typevars Args
-  ).
+typeof (c Constructor TypArgs Args) (tc TC TypArgs) :-
+  argumentsof Constructor TC PolyC,
+  applymany PolyC TypArgs Typs,
+  ((map : A -> list B -> list C -> prop) typeof Args Typs).
 
 (*
-
-specof (struct_datatype Datatype) (sig_datatype Datatype)
-       ((datatype DataType) : ConstructorAssumptions) :-
-  eq Datatype (datatype_decl TypeName Declaration),
-  (datatype (datatype_decl TypeName Declaration) ->
-    wf_constructors
-
-
-We will also need predicates that relate definitions to specifications, and structures
-to signatures. (We will focus on principal signatures for the time being, 
-
 *)
-
-specof : string -> declaration -> specification -> list prop -> type.
-sigof : struct -> sig -> type.
-
-(*
-
-*)
-
-sigof (struct S) (sig SI) :-
-  principal_sigof S SI',
-  sigmatch SI' SI.
-
-principal_sigof (struct []) [].
-principal_sigof ((S, Decl) :: Decls) ((S, Spec) :: Specs) :-
-  principal_sigof S Decl Spec Assumptions,
-  assumemany Assumptions (sigof Decls Specs).
-  
-
-We need a predicate that relates definitions to specifications:
-
-*)
-

--- a/examples/paper/04-ml-subset.md
+++ b/examples/paper/04-ml-subset.md
@@ -226,6 +226,7 @@ Example:
     (main (constr lcons [zero, constr lnil []]))
 
     )))))),
+
  wfprogram _PROGRAM,
  eval _PROGRAM FINAL) ?
 ```

--- a/examples/paper/04-ml-subset.md
+++ b/examples/paper/04-ml-subset.md
@@ -1,0 +1,159 @@
+```makam
+%use "03-dependent-binding".
+```
+
+Let us now proceed to encode more features of a programming language like ML using the
+techniques we have seen so far.
+
+First, let's add polymorphism, therefore extending our simply typed lambda calculus to
+System F. We will only consider the explicit polymorphism case for the time being, and
+explore type inference later.
+
+We need a type for quantification over types, as well as term-level constructs for
+functions over types and instantiating a polymorphic function with a specific type.
+
+```makam
+forall : (typ -> typ) -> typ.
+lamt : (typ -> term) -> term.
+appt : term -> typ -> term.
+```
+
+The typing rules are similarly straightforward.
+
+```makam
+typeof (lamt E) (forall T) :-
+  (a:typ -> typeof (E a) (T a)).
+
+typeof (appt E T) (TF T) :-
+  typeof E (forall TF).
+```
+
+One thing to note is that in a pen-and-paper version we would need to define a new
+context that keeps track of type variables that are in scope (typically named
+$\Delta$), and an auxiliary judgement of the form $\Delta \vdash \tau \text{wf}$ that
+checks that all type variables used in $\tau$ are in scope. Here we get type
+well-formedness for free. Furthermore, if we had to keep track of further information
+about type variables (e.g. their kind), we could have added an assumption of the form
+`kindof a K ->`. Since the local assumption context can carry rules for any predicate,
+no extra declaration or change to the existing rules would be needed, as would be
+required in the pen-and-paper version in order to incorporate the new $\Delta$
+context.
+
+With these additions, we can give a polymorphic type to the identity function:
+
+```makam
+typeof (lamt (fun a => lam a (fun x => x))) T ?
+```
+
+Moving on towards a more ML-like language, we would like to add the option to declare
+algebraic datatypes. This requires us to first introduce a notion of top-level
+programs, composed of a series of declarations of types and terms, as well as 
+a predicate to check that a program is well-formed. In keeping with an
+ML-like language, we could do something more general than that: add ML-style modules.
+We will need to introduce the ability to create module structures and signatures --
+corresponding to the implementation and specification parts of modules. Structures
+are composed of a series of declarations, while signatures are composed of a series
+of specifications. Therefore:
+
+```makam
+declaration, specification : type.
+struct, sig : type.
+
+struct : list declaration -> struct.
+sig : list specification -> sig.
+```
+
+`let` definitions are our first example of a module component:
+
+```makam
+let : string -> term -> declaration.
+val : string -> typ -> specification.
+```
+
+One thing to note is the presence of strings: as opposed to what we've seen so far,
+we'll be using concrete strings in the different components of structures and
+signatures, as opposed to abstract binders through higher-order abstract syntax. The
+reason for this is two-fold: first, matching components between a structure and a
+signature is done based on their concrete names; and second, there is not really a
+case where we would need substitution for the abstract variables, have we used those
+instead. As a result, we do not have to use a higher-order representation for the
+variables used in modules, and we can go with a normal first-class representation
+instead.
+
+The typing rule of a `let` declaration should make sure that the term matches the type
+of the corresponding `val` specification, and also that the corresponding named
+variable gets the right type in the rest of the module. In order to be able to capture
+the latter part, we will use a list of propositions, representing local assumptions
+that should be made in the rest of the module. We will also need a term constructor
+for named variables:
+
+```makam
+named : string -> term.
+specof : declaration -> specification -> list prop -> prop.
+specof (let S E) (val S T) [typeof (named S) T] :-
+  typeof E T.
+```
+
+Let us now move on to datatypes. Datatypes have a name, a number of type parameters,
+and a list of constructors; constructors themselves have a name and a list of
+arguments. We will only allow transparent datatypes for now, whose specification
+matches their declaration.
+
+```makam
+datatype_decl, constructor_decl : type.
+datatype_decl : string -> dbind typ T (list constructor) -> datatype_decl.
+constructor_decl : string -> subst typ T' -> constructor_decl.
+struct_datatype : datatype_decl -> declaration.
+sig_datatype : datatype_decl -> specification.
+```
+
+We will also need type- and term-level constructs for referring to a datatype and
+a constructor, respectively:
+
+```makam
+d : string -> subst typ T -> typ.
+c : string -> subst term T -> term.
+```
+
+Typing:
+
+```makam
+datatype : datatype_decl -> prop.
+
+wftype : typ -> prop.
+wftype (d S Args) :-
+  datatype (datatype_decl S Decl),
+  intromany Decl (pfun typevars =>
+    map (pfun var arg => wftype arg) typevars Args
+  ).
+```
+
+specof (struct_datatype Datatype) (sig_datatype Datatype)
+       ((datatype DataType) : ConstructorAssumptions) :-
+  eq Datatype (datatype_decl TypeName Declaration),
+  (datatype (datatype_decl TypeName Declaration) ->
+    wf_constructors
+
+
+We will also need predicates that relate definitions to specifications, and structures
+to signatures. (We will focus on principal signatures for the time being, 
+
+```makam
+specof : string -> declaration -> specification -> list prop -> type.
+sigof : struct -> sig -> type.
+```
+
+```makam
+sigof (struct S) (sig SI) :-
+  principal_sigof S SI',
+  sigmatch SI' SI.
+
+principal_sigof (struct []) [].
+principal_sigof ((S, Decl) :: Decls) ((S, Spec) :: Specs) :-
+  principal_sigof S Decl Spec Assumptions,
+  assumemany Assumptions (sigof Decls Specs).
+  
+
+We need a predicate that relates definitions to specifications:
+
+```makam

--- a/examples/paper/04-ml-subset.md
+++ b/examples/paper/04-ml-subset.md
@@ -124,5 +124,5 @@ c : constructor -> subst typ T -> list term -> term.
 typeof (c Constructor TypArgs Args) (tc TC TypArgs) :-
   argumentsof Constructor TC PolyC,
   applymany PolyC TypArgs Typs,
-  ((map : A -> list B -> list C -> prop) typeof Args Typs).
+  map typeof Args Typs.
 ```

--- a/examples/paper/04-ml-subset.md
+++ b/examples/paper/04-ml-subset.md
@@ -5,12 +5,12 @@
 Let us now proceed to encode more features of a programming language like ML using the
 techniques we have seen so far.
 
-First, let's add polymorphism, therefore extending our simply typed lambda calculus to
-System F. We will only consider the explicit polymorphism case for the time being, and
-explore type inference later.
+First, let's add polymorphism, therefore extending our simply typed lambda calculus to System
+F. We will only consider the explicit polymorphism case for the time being, and explore type
+inference later.
 
-We need a type for quantification over types, as well as term-level constructs for
-functions over types and instantiating a polymorphic function with a specific type.
+We need a type for quantification over types, as well as term-level constructs for functions
+over types and instantiating a polymorphic function with a specific type.
 
 ```makam
 forall : (typ -> typ) -> typ.
@@ -28,15 +28,14 @@ typeof (appt E T) (TF T) :-
   typeof E (forall TF).
 ```
 
-One thing to note is that in a pen-and-paper version we would need to define a new
-context that keeps track of type variables that are in scope (typically named
-$\Delta$), and an auxiliary judgement of the form $\Delta \vdash \tau \text{wf}$ that
-checks that all type variables used in $\tau$ are in scope. Here we get type
-well-formedness for free. Furthermore, if we had to keep track of further information
-about type variables (e.g. their kind), we could have added an assumption of the form
-`kindof a K ->`. Since the local assumption context can carry rules for any predicate,
-no extra declaration or change to the existing rules would be needed, as would be
-required in the pen-and-paper version in order to incorporate the new $\Delta$
+One thing to note is that in a pen-and-paper version we would need to define a new context that
+keeps track of type variables that are in scope (typically named $\Delta$), and an auxiliary
+judgement of the form $\Delta \vdash \tau \text{wf}$ that checks that all type variables used
+in $\tau$ are in scope. Here we get type well-formedness for free. Furthermore, if we had to
+keep track of further information about type variables (e.g. their kind), we could have added
+an assumption of the form `kindof a K ->`. Since the local assumption context can carry rules
+for any predicate, no extra declaration or change to the existing rules would be needed, as
+would be required in the pen-and-paper version in order to incorporate the new $\Delta$
 context.
 
 With these additions, we can give a polymorphic type to the identity function:
@@ -45,18 +44,18 @@ With these additions, we can give a polymorphic type to the identity function:
 typeof (lamt (fun a => lam a (fun x => x))) T ?
 ```
 
-Moving on towards a more ML-like language, we would like to add the option to declare
-algebraic datatypes. This requires us to first introduce a notion of top-level
-programs, composed of a series of declarations of types and terms, as well as 
-a predicate to check that a program is well-formed:
+Moving on towards a more ML-like language, we would like to add the option to declare algebraic
+datatypes. This requires us to first introduce a notion of top-level programs, composed of a
+series of declarations of types and terms, as well as a predicate to check that a program is
+well-formed:
 
 ```makam
 program : type.
 wfprogram : program -> prop.
 ```
 
-Let us add `let` definitions as a first example of a program component. These introduce
-a term variable that can be used in the rest of the program:
+Let us add `let` definitions as a first example of a program component. These introduce a term
+variable that can be used in the rest of the program:
 
 ```makam
 let : term -> (term -> program) -> program.
@@ -66,8 +65,8 @@ wfprogram (let E P) :-
   (x:term -> typeof x T -> wfprogram (P x)).
 ```
 
-We also need a "last" component for the program -- typically this takes the form of
-a main expression:
+We also need a "last" component for the program -- typically this takes the form of a main
+expression:
 
 ```makam
 main : term -> program.
@@ -76,53 +75,106 @@ wfprogram (main E) :-
   typeof E _.
 ```
 
-Let us now proceed to algebraic datatypes. Datatypes have a name, a number of type
-parameters, and a list of constructors; constructors themselves have a name and a list
-of arguments:
+Let us now proceed to algebraic datatypes. Datatypes have a name, a number of type parameters,
+and a list of constructors; constructors themselves have a name and a list of arguments:
 
 ```makam
 typeconstructor : type -> type.
 constructor : type.
 
 constructor_declaration : type -> type.
-cdnil : constructor_declaration unit.
-cdcons : list typ -> constructor_declaration T -> constructor_declaration (constructor * T).
+nil : constructor_declaration unit.
+cons : list typ -> constructor_declaration T -> constructor_declaration (constructor * T).
+datatype_declaration : type -> type -> type.
+datatype_declaration : 
+  (typeconstructor Arity -> dbind typ Arity (constructor_declaration Constructors)) ->
+  datatype_declaration Arity Constructors.
 
-datatype_declaration :
-  (typeconstructor T -> dbind typ T (constructor_declaration C)) ->
-  (typeconstructor T -> dbind constructor C program) ->
+datatype :
+  datatype_declaration Arity Constructors ->
+  (typeconstructor Arity -> dbind constructor Constructors program) ->
   program.
 ```
 
-Adding the necessary predicates:
+The datatype introduces a type constructor, as well as a number of constructors in the rest of
+the program. Here we use dependency to carry the arity of the type constructor in its
+meta-level type, avoiding the need for a well-formedness predicate for types. Of course, in
+situations where object-level types are more complicated, we would need to incorporate kind
+checking into our predicates.
+
+Let us now proceed to well-formedness for datatype declarations. We will need two auxiliary
+predicates: one that keeps information about a constructor -- which type it belongs to, what
+arguments it expects; and another one that "introduces" constructors into the rest of the
+program -- similar to the `intromany` predicate we have seen before.
 
 ```makam
-argumentsof : constructor -> typeconstructor T -> dbind typ T (list typ) -> prop.
+constructor_info :
+  constructor -> typeconstructor Arity -> dbind typ Arity (list typ) -> prop.
 
-open_constructors : [T C]
-  typeconstructor T -> subst typ T -> constructor_declaration C -> (subst constructor C -> prop) -> prop.
-open_constructors _ _ cdnil P :- P [].
-open_constructors TC TVars (cdcons ConstructorType CS) P :-
-  applymany PolyC TVars ConstructorType,
+intro_constructors : [Arity Constructors]
+  typeconstructor Arity -> subst typ Arity ->
+  constructor_declaration Constructors -> (subst constructor Constructors -> prop) -> prop.
+
+intro_constructors _ _ [] P :- P [].
+intro_constructors TypConstr TypVars (ConstructorType :: Constructors) P :-
+  applymany PolyType TypVars ConstructorType,
   (c:constructor ->
-   argumentsof c TC PolyC -> open_constructors TC Subst CS (pfun cs => P (c :: cs))).
+   constructor_info c TypConstr PolyType ->
+   intro_constructors TypConstr TypVars Constructors (pfun cs => P (c :: cs))).
+```
 
-wfprogram (datatype_declaration Constructors Rest) :-
+One interesting part in this one is the `applymany`: this is used in the opposite direction
+than what we have used it so far, getting `TypVars` and `ConstructorType` as inputs, and
+producing `PolyType` as an output. This is done so that we abstract over the type variables
+used in the datatype declaration, creating a polymorphic type for the type of the constructor,
+that can be instantiated with different types at different places.
+
+```makam
+wfprogram (datatype (datatype_declaration ConstructorDecls) Rest) :-
   (dt:(typeconstructor T) ->
-    openmany (Constructors dt) (pfun tvars constructor_decls =>
-      open_constructors dt tvars constructor_decls (pfun constructors => ([Program']
+    openmany (ConstructorDecls dt) (pfun tvars constructor_decls => 
+      intro_constructors dt tvars constructor_decls (pfun constructors => ([Program']
         applymany (Rest dt) constructors Program',
         wfprogram Program')))).
 ```
 
-Let's add term- and type-level formers:
+In order to be able to refer to datatypes and constructors, we will need type- and term-level
+formers.
 
 ```makam
-tc : typeconstructor T -> subst typ T -> typ.
-c : constructor -> subst typ T -> list term -> term.
+tconstr : typeconstructor T -> subst typ T -> typ.
+constr : constructor -> list term -> term.
 
-typeof (c Constructor TypArgs Args) (tc TC TypArgs) :-
-  argumentsof Constructor TC PolyC,
-  applymany PolyC TypArgs Typs,
+typeof (constr Constructor Args) (tconstr TypConstr TypArgs) :-
+  constructor_info Constructor TypConstr PolyType,
+  applymany PolyType TypArgs Typs,
   map typeof Args Typs.
+```
+
+We will also need pattern matching:
+
+```makam
+patt_constr : constructor -> pattlist T T' -> patt T T'.
+
+typeof (patt_constr Constructor Args) S' S (tconstr TypConstr TypArgs) :-
+  constructor_info Constructor TypConstr PolyType,
+  applymany PolyType TypArgs Typs,
+  typeof Args S' S Typs.
+```
+
+As an example, we will define lists, and the append function for them:
+
+```makam
+%debug+.
+wfprogram
+
+  (datatype
+    (datatype_declaration (fun llist => dbindnext (fun a => dbindbase (
+    [ [] (* nil *) ,
+      [a, tconstr llist [a]] (* cons of a * list a *) ]))))
+  (fun llist => dbindnext (fun lnil => dbindnext (fun lcons => dbindbase (
+
+  (main (constr lcons [zero, constr lnil []]))
+  
+))))) ?
 ```

--- a/examples/paper/04-ml-subset.md
+++ b/examples/paper/04-ml-subset.md
@@ -101,11 +101,11 @@ argumentsof : constructor -> typeconstructor T -> dbind typ T (list typ) -> prop
 
 open_constructors : [T C]
   typeconstructor T -> subst typ T -> constructor_declaration C -> (subst constructor C -> prop) -> prop.
-open_constructors _ _ cdnil P :- P snil.
+open_constructors _ _ cdnil P :- P [].
 open_constructors TC TVars (cdcons ConstructorType CS) P :-
   applymany PolyC TVars ConstructorType,
   (c:constructor ->
-   argumentsof c TC PolyC -> open_constructors TC Subst CS (pfun cs => P (scons c cs))).
+   argumentsof c TC PolyC -> open_constructors TC Subst CS (pfun cs => P (c :: cs))).
 
 wfprogram (datatype_declaration Constructors Rest) :-
   (dt:(typeconstructor T) ->

--- a/grammars/fixedLamProlog.peg
+++ b/grammars/fixedLamProlog.peg
@@ -144,8 +144,8 @@ apptyp -> x:loced(typconstr)
 
 typconstr -> id:ltoken(tident) args:repWHITE(basetyp) << id, args >>
 
-basetyp -> id:ltoken("type")   << { content = { _tType with loc = id.span } ; span = id.span } >>
-         / id:ltoken(tident)  << autospan_un (_tVar ~args:[]) id >>
+basetyp -> id:ltoken(tident)  << autospan_un (_tVar ~args:[]) id >>
+         / id:ltoken("type")   << { content = { _tType with loc = id.span } ; span = id.span } >>
          / t:lparenthesized(lmonotyp)   << t >>
 
 binding -> token("(") ids:repWHITE(ltoken(identnamed)) token(":") t:lmonotyp token(")")

--- a/grammars/fixedLamProlog.peg
+++ b/grammars/fixedLamProlog.peg
@@ -88,6 +88,8 @@ appexpr -> f:baseexpr^ args:repWHITE(baseexpr)
 namepref -> "^n" / "ⁿ" ;
 
 baseexpr -> id:ltoken(qualident)   << autospan_un mkVar id >>
+          / id:ltoken(("_" x:ident << "_" ^ x >> / "_" << "_" >>))
+            << autospan_un mkCapturingVar id >>
           / id:ltoken(identnamed)  << autospan_un mkVar id >>
           / x:ltoken( ( namepref id:ident << id >>) ) << autospan_un mkNameVar x >>
           / id:ltoken( ("#" s:identany << s >>) ) << autospan_un mkCapturingVar id >>


### PR DESCRIPTION
This basically adds datatypes, plus top-level programs. Modules proved to be complicated enough and leading to various asides; I feel like they are not adding much to the narrative compared to this one.
This does not introduce new techniques really, but it's a good application of what we have so far. There's one or two interesting places in the code itself -- most a nice replacement of free variables by a bound variable through higher-order unification that reads very nicely.

Plans for next steps:
- ~~I will try to add type synonyms to the top-level declarations. That should give us a nice segue into reflective predicates, as an easy way to incorporate a conversion-like rule without changing all the rules is to do a bit of reflection (normalize types when you read them off an assumption, and when doing type analysis in the bidirectional sense -- that is, when you already have a concrete type you need to match --, do synthesis instead and check whether the two types normalize to the same one). However, this sometimes ends up in divergence, so not sure if I'll be able to write this nicely yet.~~
- ~~I will add a structurally recursive predicate; I think I'll go with something that desugars a case statement into a series of `case_or_else` statements.~~ Both of these are in #10 now.
- ~~Then I'll work on the VeriML-like-language encoding.~~ This is #12 .

@achlipala 