### PR TITLE
string expansions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,16 +27,15 @@ jobs:
           command: opam config exec make makam-tests
 
       - run: &compile-js
-          name: Compile Makam.js
-          command: opam config exec make js
+          name: Install Node.js and compile Makam.js
+          command:  |
+            opam config exec make js
+            curl -sL https://deb.nodesource.com/setup_9.x | sudo -E bash -
+            sudo apt-get install -y nodejs
 
       - run: &tests-js
           name: Run Tests for Makam.js
-          command: |
-            curl -sL https://deb.nodesource.com/setup_9.x | sudo -E bash -
-            sudo apt-get install -y nodejs
-            echo '%use "stdlib/parsing/tests". run_tests X ?' | node js/ | tee output | grep SUCCESSFUL
-            cat output
+          command: make makam-js-tests
 
 workflows:
   version: 2

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,11 @@ configure:
 makam-tests:
 	makam --run-tests all_tests
 
+makam-js-tests:
+	echo '%use "stdlib/parsing/tests". run_tests X ?' | node js/ | tee output | grep SUCCESSFUL
+	cat output
+	rm output
+
 OCAMLBUILD=ocamlbuild -use-ocamlfind -byte-plugin
 MAKAMFILES=$(foreach file, $(shell find . -name \*.makam), --file $(file):/$(file))
 MAKAM_MARKDOWN_FILES=$(foreach file, $(shell find examples -name \*.md), --file $(file):/$(file))
@@ -57,4 +62,4 @@ md2makam:
 md2makam-watch:
 	while true; do inotifywait -e modify `git ls-files --cached --others */*.md` && find -name \*.md -exec grep -l "^\`\`\`makam" {} \; | xargs -n 1 -r awk -f scripts/generate-makam.awk; done
 
-.PHONY: js md2makam md2makam-watch makam-tests
+.PHONY: js md2makam md2makam-watch makam-tests makam-js-tests

--- a/examples/all_tests.makam
+++ b/examples/all_tests.makam
@@ -5,6 +5,10 @@ all_tests : testsuite.
 
 %use "stdlib/parsing/tests".
 
+%extend dyn_expansion.
+%use "stdlib/dyn_expansion".
+%end.
+
 %use "new/testocaml".
 
 %use "new/testcases_ocaml".

--- a/examples/small/systemf.makam
+++ b/examples/small/systemf.makam
@@ -8,6 +8,7 @@ term : type.
 typ  : type.
 
 lam : (term -> term) -> term .
+lam : typ -> (term -> term) -> term.
 app : term -> term -> term .
 eunit : term .
 
@@ -18,6 +19,9 @@ typeof : term -> typ -> prop .
 typeof eunit tunit .
 
 typeof (lam E) (arrow T1 T2) <-
+  (x:term -> typeof x T1 -> typeof (E x) T2) .
+
+typeof (lam T1 E) (arrow T1 T2) <-
   (x:term -> typeof x T1 -> typeof (E x) T2) .
 
 typeof (app E1 E2) T2 <-

--- a/grammars/makamGrammar.peg
+++ b/grammars/makamGrammar.peg
@@ -131,6 +131,10 @@ baseexpr -> id:ltoken(qualident)   << autospan_un mkVar id >>
           / s:loced( ( token(["]) str:rep(strchar) ["] << str |> String.concat "" >> ) )
             << autospan_un mkString s >>
 
+          (* string expansions *)
+          / token("`") l:rep(expansion) nilspan:loced("`")
+            << mkTm "expansion" [ mkList nilspan l ] >>
+
           (* lists *)
           / token("[") es:repSEP(lexpr, ",") nilspan:ltoken("]")
             << mkList nilspan es >>
@@ -251,7 +255,15 @@ def       -> ids:repplusSEP(token(ident^), ",")  token(":") t:typ
 (* base/profiling versions *)
 
 prologcmd1 ->
-             d:defBM token(".") << fun () -> (
+             token("`(") p:hyp token(")") token(".")
+             << fun () -> (global_set_last_query None;
+                          if !_ONLY_TYPECHECK then
+                             (Benchmark.cumulative "total queries" (lazy(global_typecheck_silent p.content)))
+                          else
+                             (Benchmark.cumulative "total staged commands"
+                                (lazy(Termlangrefl.global_staged_command p.content)))) >>
+
+           / d:defBM token(".") << fun () -> (
                 global_set_last_query None;
                 Benchmark.cumulative "total defs"
                 (lazy(List.iter (uncurry global_define) d))) >>
@@ -262,14 +274,6 @@ prologcmd1 ->
                                                  else
                                                   (Benchmark.cumulative "total clauses"
                                                     (lazy(Termlangprolog.global_new_clause c.content)))) >>
-           / token("`(") p:hyp token(")") token(".")
-             << fun () -> (global_set_last_query None;
-                          if !_ONLY_TYPECHECK then
-                             (Benchmark.cumulative "total queries" (lazy(global_typecheck_silent p.content)))
-                          else
-                             (Benchmark.cumulative "total staged commands"
-                                (lazy(Termlangrefl.global_staged_command p.content)))) >>
-
            / p:hyp token("?") << fun () -> (global_set_last_query (Some p);
                                             if !_ONLY_TYPECHECK then
                                              (Benchmark.cumulative "total queries"
@@ -497,6 +501,16 @@ strchar ->  s:escapechar << Utils.unescape s >>
          / !"\"" c:. << ([ c ] |> UString.implode) |> UString.to_string >>
 str     -> token(["]) str:rep(strchar) ["] << str |> String.concat "" >>
 
+(* string expansions *)
+expansion_char ->
+    s:escapechar << Utils.unescape s >>
+  / s:"\\`"       << "`" >>
+  / s:"\\$"       << "$" >>
+  / !"`" !"$" c:.     << ([ c ] |> UString.implode) |> UString.to_string >>
+
+expansion ->
+   str:loced( (s:repplus(expansion_char) << s |> String.concat "" >>) ) << autospan_un mkString str >>
+ / "${" t:lexpr token("}") << t >>
 
 ocamlrevchar  -> !"<<" c:. << c >>
 ocamlrevtext  -> cs:repplus(ocamlrevchar) << (cs |> UString.implode) |> UString.to_string >>

--- a/opam/files/makam.install
+++ b/opam/files/makam.install
@@ -31,4 +31,5 @@ share: [
   "stdlib/tuple.makam" {"stdlib/tuple.makam"}
   "stdlib/typ.makam" {"stdlib/typ.makam"}
   "stdlib/vars.makam" {"stdlib/vars.makam"}
+  "stdlib/dyn_expansion.makam" {"stdlib/dyn_expansion.makam"}
 ]

--- a/stdlib/dyn_expansion.makam
+++ b/stdlib/dyn_expansion.makam
@@ -1,0 +1,39 @@
+(* expansions that allow quotes of types other than `string`,
+   by using `tostring`. These are optional and not imported by default. *)
+
+dyn_expansion : type.
+dyn_expansion_list : type.
+expansion : dyn_expansion_list -> dyn_expansion.
+
+eval_dyn_expansion : dyn_expansion -> expansion -> prop.
+
+nil : dyn_expansion_list.
+cons : A -> dyn_expansion_list -> dyn_expansion_list.
+
+eval_dyn_expansion (expansion []) (expansion []).
+eval_dyn_expansion (expansion (X :: TL)) (expansion (HD :: TL')) when not(typ.eq X (Z : string)) :-
+  tostring X HD, eval_dyn_expansion (expansion TL) (expansion TL').
+
+cons : string -> dyn_expansion_list -> dyn_expansion_list.
+eval_dyn_expansion (expansion ((HD : string) :: TL)) (expansion (HD :: TL')) :-
+  eval_dyn_expansion (expansion TL) (expansion TL').
+
+without_eqv_refl (X : dyn_expansion).
+
+eqv A B :-
+  eval_dyn_expansion A A',
+  eval_dyn_expansion B B',
+  eqv A' B'.
+
+tostring_def (X: dyn_expansion) S :-
+  eval_dyn_expansion X X',
+  tostring X' S.
+
+print_string (X: dyn_expansion) :-
+  tostring X S, print_string S.
+
+dyn_expansion : testsuite. %testsuite dyn_expansion.
+
+>> tostring `${true} or ${false}` X ?
+>> Yes:
+>> X := "true or false".

--- a/stdlib/init.makam
+++ b/stdlib/init.makam
@@ -6,7 +6,6 @@
 %use guard.
 
 %use list.
-%use string.
 
 %use demand.
 %use testing.
@@ -24,6 +23,8 @@
 
 %use morerefl.
 %use reify.
+
+%use string.
 
 %use vars.
 

--- a/stdlib/list.makam
+++ b/stdlib/list.makam
@@ -74,6 +74,9 @@ concat LS L <-
   map catenable LS LS', reverse LS' LS'rev,
   foldl (fun cur lst => eq (lst cur)) nil LS'rev L.
 
+prefix : list A -> list A -> list A -> prop.
+prefix [] L L.
+prefix (PrefHD :: PrefTL) (PrefHD :: TL) Rest :- prefix PrefTL TL Rest.
 
 (* Find element matching a predicate *)
 find : (A -> prop) -> list A -> A -> prop.

--- a/stdlib/string.makam
+++ b/stdlib/string.makam
@@ -1,8 +1,28 @@
 %extend string.
 
 concat : list string -> string -> prop.
+
+concat_backwards : list string -> list (reified string) -> list string -> prop.
+
+concat_backwards [] [] [].
+
+concat_backwards Consume (reified.unifvar _ _ _ X :: Rest) Consume'' :-
+  prefix Prefix Consume Consume',
+  string.explode X Prefix,
+  concat_backwards Consume' Rest Consume''.
+
+concat_backwards Consume (reified.const S :: Rest) Consume'' :-
+  string.explode S SL,
+  append SL Consume' Consume,
+  concat_backwards Consume' Rest Consume''.
+
 concat Strings Result <-
-  foldl append "" Strings Result.
+  if (refl.isunif Result) then
+    foldl append "" Strings Result
+  else (
+    map reify Strings StringsR,
+    string.explode Result ResultL,
+    concat_backwards ResultL StringsR []
+  ).
 
 %end.
-

--- a/stdlib/string.makam
+++ b/stdlib/string.makam
@@ -26,3 +26,42 @@ concat Strings Result <-
   ).
 
 %end.
+
+%extend builtin.
+tostring : [A]A -> string -> prop.
+tostring X S :- .tostring X S.
+
+print_string : string -> prop.
+print_string X :- .print_string X.
+%end.
+
+tostring, tostring_def : [A]A -> string -> prop.
+tostring X S :- if (tostring_def X S) then success else (builtin.tostring X S).
+
+print_string : [A]A -> prop.
+print_string (S : string) :- builtin.print_string S.
+
+
+expansion : type.
+expansion : list string -> expansion.
+
+%extend expansion.
+isconcrete : expansion -> prop.
+isconcrete E when not(refl.isunif E), eq E (expansion L), not(refl.isunif L) :-
+  map (pfun s => not(refl.isunif s)) L.
+%end.
+
+without_eqv_refl (_ : expansion).
+
+eqv (expansion A) (expansion B) when expansion.isconcrete (expansion A) :-
+  string.concat A A',
+  string.concat B A'.
+
+eqv (expansion A) (expansion B) when not(expansion.isconcrete (expansion A)), expansion.isconcrete (expansion B) :-
+  string.concat B B',
+  string.concat A B'.
+
+tostring_def (expansion X) S when expansion.isconcrete (expansion X) :-
+  string.concat X S.
+
+print_string (X : expansion) :- tostring X S, builtin.print_string S.

--- a/stdlib/tests.makam
+++ b/stdlib/tests.makam
@@ -224,4 +224,9 @@ let_in : term -> (term -> term) -> term.
 >> A := app (freevar "a") (freevar "b"),
 >> B := fun x => app x unit.
 
+
+(* ------------------- string *)
+
+
+
 %end.

--- a/stdlib/tests.makam
+++ b/stdlib/tests.makam
@@ -227,6 +227,49 @@ let_in : term -> (term -> term) -> term.
 
 (* ------------------- string *)
 
+>> string.concat [ "foo", "bar" ] X ?
+>> Yes:
+>> X := "foobar".
 
+>> string.concat [] X ?
+>> Yes:
+>> X := "".
+
+>> string.concat [ "foo", X ] "foobar" ?
+>> Yes:
+>> X := "bar".
+
+>> string.concat [ X, "bar" ] "foobar" ?
+>> Yes:
+>> X := "foo".
+
+>> string.concat [ X, "bar" ] "foobaz" ?
+>> Impossible.
+
+>> string.concat [ "fo", X, "ar" ] "foobar" ?
+>> Yes:
+>> X := "ob".
+
+>> string.concat [ F, "o", O, "b", A, "r", Z ] "foobar" ?
+>> Yes:
+>> F := "f",
+>> O := "o",
+>> A := "a",
+>> Z := "".
+
+>> eqv `hello${X}world!` `hello world!` ?
+>> Yes:
+>> X := " ".
+
+>> eqv `hello world!` `hello${X}world!` ?
+>> Yes:
+>> X := " ".
+
+>> eqv `hello ${"world"}!` `hello world!` ?
+>> Yes.
+
+>> ((pfun x => eqv `hello ${x}!` `hello world!`) X) ?
+>> Yes:
+>> X := "world".
 
 %end.


### PR DESCRIPTION
- made `string.concat` work backwards too
- added expansions which are lists of strings, equivalent up to concatenation
- added grammar extension for expansions
- added optional dynamic expansions that call `tostring` on non-`string` quoted terms
- CircleCI now runs some tests for `makam.js`.
