### PR TITLE
fix download cache from S3

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -1,6 +1,6 @@
 OASISFormat: 0.4
 Name:        makam
-Version:     0.7.0
+Version:     0.7.1
 Synopsis:    The Makam Metalanguage -- a tool for rapid language prototyping
 Authors:     Antonis Stampoulis <antonis.stampoulis@gmail.com>
 Homepage:    http://astampoulis.github.io/

--- a/js/index.html
+++ b/js/index.html
@@ -10,7 +10,7 @@
 
       var worker = new Worker('makam.js');
       var terminal = null;
-      const version = "0.7.0";
+      const version = "0.7.1";
      
       $(function() {
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "makam",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "The Makam metalanguage -- a tool for rapid language prototyping",
   "main": "lib/index.js",
   "scripts": {

--- a/opam/opam
+++ b/opam/opam
@@ -1,6 +1,6 @@
 opam-version: "1.2"
 name: "makam"
-version: "0.7.0"
+version: "0.7.1"
 maintainer: "Antonis Stampoulis <antonis.stampoulis@gmail.com>"
 authors: [ "Antonis Stampoulis <antonis.stampoulis@gmail.com>" ]
 license: "GPL-3"

--- a/scripts/source-hash.sh
+++ b/scripts/source-hash.sh
@@ -6,7 +6,7 @@ set -o pipefail
 TOPDIR=$(git rev-parse --show-toplevel)
 
 function sourceHash() {
-  SOURCE_FILES=$(cd $TOPDIR; git ls-files | grep -E "((^opam)|(\.(ml|ml4|peg)$))" | grep -E --invert-match "(setup|version)\.ml$")
+  SOURCE_FILES=$(cd $TOPDIR; git ls-files | grep -E "\.(ml|ml4|peg)$" | grep -E --invert-match "(setup|version)\.ml$")
   (cd $TOPDIR; find $SOURCE_FILES -print0 | xargs -0 shasum | sort | shasum | cut -f 1 -d' ')
 }
 

--- a/scripts/webservice-deploy.sh
+++ b/scripts/webservice-deploy.sh
@@ -31,7 +31,6 @@ elif [[ ${1:x} == "prod" ]]; then
 
 elif [[ ${1:-x} == "x" ]]; then
 
-  DO_BUILD=1
   PACKAGE_VERSION=$(cd $TOPDIR; ./scripts/makam-version.sh npm-test-version)
 
 else

--- a/toploop/version.ml
+++ b/toploop/version.ml
@@ -1,2 +1,2 @@
-let version = "0.7.0" ;;
-let source_hash = "0f0ce6e3d68f4bb7624483f9786618e85440871e";;
+let version = "0.7.1" ;;
+let source_hash = "ab5b2b2d664254ef108e8a5da9f0fad842172786";;

--- a/webservice/package.json
+++ b/webservice/package.json
@@ -10,7 +10,7 @@
   "license": "GPL-3.0",
   "devDependencies": {
     "aws-sdk": "^2.181.0",
-    "serverless": "^1.25.0",
+    "serverless": "^1.26.0",
     "serverless-s3-remover": "^0.4.1"
   },
   "dependencies": {

--- a/webservice/yarn.lock
+++ b/webservice/yarn.lock
@@ -582,6 +582,10 @@ eyes@0.1.x:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/eyes/-/eyes-0.1.8.tgz#62cf120234c683785d902348a800ef3e0cc20bc0"
 
+fast-levenshtein@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
+
 fd-slicer@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/fd-slicer/-/fd-slicer-1.0.1.tgz#8b5bcbd9ec327c5041bf9ab023fd6750f1177e65"
@@ -1455,9 +1459,9 @@ serverless-s3-remover@^0.4.1:
     chalk "^2.1.0"
     prompt "^1.0.0"
 
-serverless@^1.25.0:
-  version "1.25.0"
-  resolved "https://registry.yarnpkg.com/serverless/-/serverless-1.25.0.tgz#23922d6514fcd9217d2740a52ba17c696734fb23"
+serverless@^1.26.0:
+  version "1.26.0"
+  resolved "https://registry.yarnpkg.com/serverless/-/serverless-1.26.0.tgz#cd46345a25d9fdd6c7a9c1da95251de39053ddae"
   dependencies:
     "@serverless/fdk" "^0.5.1"
     apollo-client "^1.9.2"
@@ -1468,6 +1472,7 @@ serverless@^1.25.0:
     chalk "^2.0.0"
     ci-info "^1.1.1"
     download "^5.0.2"
+    fast-levenshtein "^2.0.6"
     filesize "^3.3.0"
     fs-extra "^0.26.7"
     get-stdin "^5.0.1"

--- a/webui/package.json
+++ b/webui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "makam-webui",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "CodeMirror-based WebUI for Makam",
   "main": "makam-webui.js",
   "scripts": {


### PR DESCRIPTION
The S3 state cache wasn't working; this fixes that. Also change the calculation of the source-hash so that it's not dependent on the version any more; so the same binary sources should lead to the same hash even if the version changes.