### PR TITLE
add destructuring pfun

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -1,6 +1,6 @@
 OASISFormat: 0.4
 Name:        makam
-Version:     0.7.2
+Version:     0.7.3
 Synopsis:    The Makam Metalanguage -- a tool for rapid language prototyping
 Authors:     Antonis Stampoulis <antonis.stampoulis@gmail.com>
 Homepage:    http://astampoulis.github.io/

--- a/grammars/makamGrammar.peg
+++ b/grammars/makamGrammar.peg
@@ -128,10 +128,29 @@ lexpr -> fn:lkeyword("fun") bindings:repplusWHITE(binding) token("=>") body:lexp
            let bindings = match bindings with hd :: tl -> { hd with span = fn ---> hd } :: tl | _ -> bindings in
            List.fold_right (fun binding body -> autospan_bin mkLamO binding body) bindings body >>
 
-       / fn:lkeyword("pfun") bindings:repplusWHITE(binding) token("=>") body:prop
-        << let bindings = List.flatten bindings in
+       / fn:lkeyword("pfun")
+         bindings:repWHITE(binding)
+         introMetas:newmetas
+         destructurings:repWHITE(baseexpr)
+         token("=>") body:prop
+        << let destructBindings =
+             List.mapi (fun i destr -> { content = ("~destruct" ^ (string_of_int i), None); span = destr.span }) destructurings
+           in
+           let destructVars =
+             List.map (fun id -> autospan_un mkVar { id with content = fst id.content }) destructBindings
+           in
+           let bindings = List.append (List.flatten bindings) destructBindings in
            let bindings = match bindings with hd :: tl -> { hd with span = fn ---> hd } :: tl | _ -> bindings in
-           List.fold_right (fun binding body -> autospan_bin mkLamO binding body) bindings body >>
+           let body =
+             match destructurings with
+               [] -> body
+             | _ :: _ ->
+               mkTm "and" [
+                 mkTm "eq" [ mkTuple destructVars; mkTuple destructurings ];
+                 body
+               ]
+           in
+           List.fold_right (fun binding body -> autospan_bin mkLamO binding body) bindings (introMetas body) >>
 
       / hd:appexpr^ token("::") tl:lexpr
         << mkTm "cons" [ hd ; tl ] >>

--- a/js/index.html
+++ b/js/index.html
@@ -10,7 +10,7 @@
 
       var worker = new Worker('makam.js');
       var terminal = null;
-      const version = "0.7.2";
+      const version = "0.7.3";
      
       $(function() {
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "makam",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "The Makam metalanguage -- a tool for rapid language prototyping",
   "main": "lib/index.js",
   "scripts": {

--- a/opam/opam
+++ b/opam/opam
@@ -1,6 +1,6 @@
 opam-version: "1.2"
 name: "makam"
-version: "0.7.2"
+version: "0.7.3"
 maintainer: "Antonis Stampoulis <antonis.stampoulis@gmail.com>"
 authors: [ "Antonis Stampoulis <antonis.stampoulis@gmail.com>" ]
 license: "GPL-3"

--- a/tests/core_tests.makam
+++ b/tests/core_tests.makam
@@ -23,4 +23,9 @@ testcase makam_core :- eq { test other markers > } " test other markers > ".
 testcase makam_core :- eq { test other markers { } " test other markers { ".
 testcase makam_core :- eq {{ test other markers } }} " test other markers } ".
 
+(* Tests for pfun *)
+
+testcase makam_core :- ((pfun [X] X => eq X 1) 1).
+testcase makam_core :- eq X 2, ((pfun [X Y] (X, Y) => eq X 1) (1, 3)).
+testcase makam_core :- (x:string -> ((pfun y [X] => eq X x) 1)).
 

--- a/toploop/version.ml
+++ b/toploop/version.ml
@@ -1,2 +1,2 @@
-let version = "0.7.2" ;;
-let source_hash = "2312d98d03b75c9a2b587f01fb5968fbd159f301";;
+let version = "0.7.3" ;;
+let source_hash = "2344432bc3e3a5dab2cc6efba9456be41935dcd6";;

--- a/webui/package.json
+++ b/webui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "makam-webui",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "CodeMirror-based WebUI for Makam",
   "main": "makam-webui.js",
   "scripts": {


### PR DESCRIPTION
Extends `pfun` syntax to allow introducing metavariables and to destructure arguments. That way we can write predicates like:
```
openmany XS_DefsBody (pfun [XS Defs Body] XS (Defs, Body) => ...)
```
