### PR TITLE
named type arguments

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -1,6 +1,6 @@
 OASISFormat: 0.4
 Name:        makam
-Version:     0.7.3
+Version:     0.7.4
 Synopsis:    The Makam Metalanguage -- a tool for rapid language prototyping
 Authors:     Antonis Stampoulis <antonis.stampoulis@gmail.com>
 Homepage:    http://astampoulis.github.io/

--- a/grammars/makamGrammar.peg
+++ b/grammars/makamGrammar.peg
@@ -208,10 +208,15 @@ annotexpr -> e:lexpr^ token(":") t:lmonotyp << autospan_bin mkAnnot e t >>
 
 typ  -> t:ltyp << t.content >>
 
-ltyp  -> s:ltoken("[") adhoc:repWHITE(token(ident)) e:ltoken("]") t:lmonotyp
-        << let adhoc = { content = adhoc ; span = s ---> e } in
-           autospan_bin _tForallAdhoc adhoc t >>
-      / t:lmonotyp << t >>
+adhoc -> s:ltoken("[") a:repWHITE(token(ident)) e:ltoken("]")
+         << let a = { content = a ; span = s ---> e } in
+            autospan_bin _tForallAdhoc a >>
+       / epsilon << fun x -> x >>
+
+ltyp  -> a:adhoc t:lmonotyp << a t >>
+       / a:adhoc ts:repplusWHITE(typebinding) token("->") t:lmonotyp
+         << let base = List.fold_right (autospan_bin _tArrow) (List.flatten ts) t in
+            a base >>
 
 lmonotyp -> t:multtyp^ token("->") e:lmonotyp     << autospan_bin _tArrow t e >>
           / t:multtyp^                            << t >>
@@ -300,6 +305,9 @@ newvar   -> id:ltoken(ident^) token(":") t:basetyp token("->") << { content = (i
 (* commands *)
 def       -> ids:repplusSEP(token(ident^), ",")  token(":") t:typ
              << List.map (fun x -> x, t) ids >>
+
+typebinding -> token("(") ids:repplusWHITE(ltoken(identnamed)) token(":") t:lmonotyp token(")")
+           << List.map (fun _ -> t) ids >>
 
 (* base/profiling versions *)
 

--- a/js/index.html
+++ b/js/index.html
@@ -10,7 +10,7 @@
 
       var worker = new Worker('makam.js');
       var terminal = null;
-      const version = "0.7.3";
+      const version = "0.7.4";
      
       $(function() {
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "makam",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "The Makam metalanguage -- a tool for rapid language prototyping",
   "main": "lib/index.js",
   "scripts": {

--- a/opam/opam
+++ b/opam/opam
@@ -1,6 +1,6 @@
 opam-version: "1.2"
 name: "makam"
-version: "0.7.3"
+version: "0.7.4"
 maintainer: "Antonis Stampoulis <antonis.stampoulis@gmail.com>"
 authors: [ "Antonis Stampoulis <antonis.stampoulis@gmail.com>" ]
 license: "GPL-3"

--- a/scripts/makam-version.sh
+++ b/scripts/makam-version.sh
@@ -121,5 +121,10 @@ has-update)
   else
     echo false
   fi
+  ;;
+
+*)
+  usage
+  exit 1
 
 esac

--- a/toploop/version.ml
+++ b/toploop/version.ml
@@ -1,2 +1,2 @@
-let version = "0.7.3" ;;
-let source_hash = "2344432bc3e3a5dab2cc6efba9456be41935dcd6";;
+let version = "0.7.4" ;;
+let source_hash = "91257f21b536c6846189ef6f2cb8746f9e12ab0b";;

--- a/webui/package.json
+++ b/webui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "makam-webui",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "CodeMirror-based WebUI for Makam",
   "main": "makam-webui.js",
   "scripts": {


### PR DESCRIPTION
This allows naming arguments on definitions, as a way to clarify what they mean. It is purely syntactic sugar. Might be temporary, but it makes some literate developments easier to follow.

Examples:
```
bindmany : (Var: type) (Body: type) -> type.
bind : (Concrete: string) (Binder: Var -> bindmany Var Body) -> bindmany Var Body.
app: (E1: term) (E2: term) -> term.
```
