### PR TITLE
Fixing the eval rule for >=

### DIFF
--- a/examples/tinyml/eval.makam
+++ b/examples/tinyml/eval.makam
@@ -63,7 +63,7 @@ eval_binop binop_lt (eint N1) (eint N2) EB :- lessthan N1 N2 B, convert_bool B E
 eval_binop binop_gt (eint N1) (eint N2) EB :- lessthan N2 N1 B, convert_bool B EB.
 eval_binop binop_eq (eint N1) (eint N2) EB :- if (eq N1 N2) then eq B true else eq B false, convert_bool B EB.
 eval_binop binop_le (eint N1) (eint N2) EB :- if (eq N1 N2) then eq B true else lessthan N1 N2 B, convert_bool B EB.
-eval_binop binop_lt (eint N1) (eint N2) EB :- if (eq N1 N2) then eq B true else lessthan N2 N1 B, convert_bool B EB.
+eval_binop binop_ge (eint N1) (eint N2) EB :- if (eq N1 N2) then eq B true else lessthan N2 N1 B, convert_bool B EB.
 
 evalprogram : program -> program -> prop.
 


### PR DESCRIPTION
Just that, fixed the evaluator rule for the >= operator.

Before
```
# interpreter {{2 >= 0}} S ?
Impossible.
```

Now
```
#  interpreter {{2 >= 0}} S ?
Yes:
S := "True() ".
#  interpreter {{2 >= 3}} S ?
Yes:
S := "False() ".
```

I'm not completely sure how the tests are written.