### PR TITLE
call-by-need lambda calculus with Launchbury semantics

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -1,6 +1,6 @@
 OASISFormat: 0.4
 Name:        makam
-Version:     0.7.17
+Version:     0.7.18
 Synopsis:    The Makam Metalanguage -- a tool for rapid language prototyping
 Authors:     Antonis Stampoulis <antonis.stampoulis@gmail.com>
 Homepage:    http://astampoulis.github.io/

--- a/examples/small/lazyeval.makam
+++ b/examples/small/lazyeval.makam
@@ -60,6 +60,9 @@ open (heap XS_DefsBody) P :-
   bindmany.open XS_DefsBody (pfun XS (Defs, Body) =>
     assumeindex XS (P XS Defs Body)).
 
+(* used as a marker to denote which definitions to keep *)
+keep : heap A -> heap A.
+
 pair, pair_ : heap A -> heap B -> heap (A * B) -> prop.
 pair A B C :- once(pair_ A B C).
 pair_ (heap (body (Defs, Body1))) (heap (body (Defs, Body2)))
@@ -176,8 +179,9 @@ eval (Heap0_Body0) (Heap0_Heap12_Body')
   heap.openmany [Heap0_Body0, Heap0_Fun] (pfun XS Defs [app E X, Fun] => eq Fun E),
 
   eval Heap0_Fun Heap0_Heap1_Body1,
-  heap.openmany [Heap0_Body0, Heap0_Heap1_Body1, Heap0_Heap1_Body2]
-    (pfun XS Defs [app E X, Heap1_Body1, Heap1_Body2] =>
+  heap.openmany [Heap0_Heap1_Body1, Heap0_Heap1_Body2]
+    (pfun XS Defs [Heap1_Body1, Heap1_Body2] => [Unused E X]
+    heap.apply Heap0_Body0 XS Unused (app E X),
     heap.openmany [Heap1_Body1, Heap1_Body2]
       (pfun XS' Defs' [lam Y_E', Body2] =>
         eq Body2 (Y_E' X))),
@@ -214,8 +218,9 @@ eval (Heap0_Body0) (Heap0_Heap12_Body')
 
   eval Heap0_E1 Heap0_Heap1_Eval1,
 
-  heap.openmany [Heap0_E2, Heap0_Heap1_Eval1, Heap0_Heap1_Body2]
-    (pfun XS Defs [E2, Heap1_Eval1, Heap1_Body2] =>
+  heap.openmany [Heap0_Heap1_Eval1, Heap0_Heap1_Body2]
+    (pfun XS Defs [Heap1_Eval1, Heap1_Body2] => [Unused E2]
+    heap.apply Heap0_E2 XS Unused E2,
     heap.openmany [Heap1_Eval1, Heap1_Body2]
       (pfun XS' Defs' [intconst N1, Body2] =>
         eq N1 N1_, eq Body2 E2)),
@@ -275,3 +280,7 @@ maintests : testsuite. %testsuite maintests.
 >> eval (heap (bind "x" (fun x => (body ([binop plus (intconst 10) (intconst 5)], binop plus (intconst 10) (var x) ))))) X ?
 >> Yes:
 >> X := heap (bind "x" (fun x => body (tuple [ (intconst 15) ] (heap (body (tuple [  ] (intconst 25))))))).
+
+>> eval (heap (bind "x" (fun x => (body ([binop plus (intconst 10) (intconst 5)], binop plus (var x) (var x) ))))) X ?
+>> Yes:
+>> X := heap (bind "x" (fun x => body (tuple [ (intconst 15) ] (heap (body (tuple [  ] (intconst 30))))))).

--- a/examples/small/lazyeval.makam
+++ b/examples/small/lazyeval.makam
@@ -20,7 +20,7 @@ binop : (int -> int -> int -> prop) -> expr -> expr -> expr.
 (* now let's model heaps. In this semantics, heaps are
    variable binding - expression definition pairs. In Makam,
    we will model them as a number of bindings followed by
-   their definitions in the same order. 
+   their definitions in the same order.
 *)
 
 heap : type -> type.
@@ -49,6 +49,16 @@ split 0 Post [] Post.
 split N (X :: XS) (X :: Pre) Post :-
   plus 1 N' N,
   split N' XS Pre Post.
+
+bring_to_top : int -> list A -> list A -> prop.
+bring_to_top Index XS (X :: XS') :-
+  split Index XS XSPre (X :: XSPost),
+  append XSPre XSPost XS'.
+
+unbring_to_top : int -> list A -> list A -> prop.
+unbring_to_top Index (X :: XS) XS' :-
+  split Index XS XSPre XSPost,
+  append XSPre (X :: XSPost) XS'.
 
 %end.
 
@@ -110,14 +120,29 @@ collapse (heap AS_BS_Body) ASBS_Body :-
       append ADefs BDefs ABDefs,
       heap.apply ASBS_Body ASBS ABDefs Body)).
 
-extract (heap ASBS_Body) (heap AS_Rest) (heap AS_BS_Body) :-
-  bindmany.pair AS_Rest AS_BS_Body Both,
-  bindmany.open Both (pfun AS (Rest, (ADefs, Heap_BS_Body)) => [BS_Body]
-    bindmany.applysome ASBS_Body AS BS_Body,
-    bindmany.open BS_Body (pfun BS (ABDefs, Body) => [BDefs]
-      heap.apply Heap_BS_Body BS BDefs Body,
-      length AS N,
-      list.split N ABDefs ADefs BDefs)).
+extract Heap HeapRef Heap' :-
+  heap.open HeapRef (pfun AS Defs Body => length AS N),
+  heap.open Heap (pfun ASBS ASBSDefs Body => [AS BS ASDefs BSDefs Heap'']
+    list.split N ASBS AS BS,
+    list.split N ASBSDefs ASDefs BSDefs,
+    heap.apply Heap' AS ASDefs Heap'',
+    heap.apply Heap'' BS BSDefs Body).
+
+bring_to_top : int -> heap A -> heap A -> prop.
+bring_to_top Index Heap Heap' :-
+  heap.open Heap (pfun XS Defs Body => [XS' Defs']
+    list.bring_to_top Index XS XS',
+    list.bring_to_top Index Defs Defs',
+    heap.apply Heap' XS' Defs' Body
+  ).
+
+unbring_to_top : int -> heap A -> heap A -> prop.
+unbring_to_top Index Heap Heap' :-
+  heap.open Heap (pfun XS Defs Body => [XS' Defs']
+    list.unbring_to_top Index XS XS',
+    list.unbring_to_top Index Defs Defs',
+    heap.apply Heap' XS' Defs' Body
+  ).
 
 tests : testsuite. %testsuite tests.
 
@@ -196,7 +221,7 @@ eval (Heap0_Body0) (Heap0_Heap12_Body')
 
   —————————————-
   Γ : n ⇓ Γ : n
-  
+
 *)
 
 eval (Heap_Body) Result
@@ -239,25 +264,68 @@ eval (Heap0_Body0) (Heap0_Heap12_Body')
            Γ : e ⇓ Δ : z
   —————————————-—————————————————————
   (Γ, x |-> e) : x ⇓ (Δ, x |-> z) : z
-  
+
 *)
 
+(*
 eval (Heap0_Body0) (Heap0_Heap1_Body')
   when heap.open Heap0_Body0 (pfun (X :: XS) (XDef :: Defs) (var X) => success) :-
 
   heap.openmany [Heap0_Body0, Heap0_E] (pfun (X :: XS) (XDef :: Defs) [var X, XDef] => success),
-  heap.extract Heap0_E (heap (bind XName (fun x => Rest x))) HeapX_HeapXS_E,
+  heap.extract Heap0_E (heap (bind XName (fun x => body (Rest x)))) HeapX_HeapXS_E,
 
   heap.openmany [HeapX_HeapXS_E, HeapX_HeapXSYS_Eval] (pfun [X] [XDef] [HeapXS_E, HeapXSYS_Eval] => [HeapXS_HeapYS_Eval]
     eval HeapXS_E HeapXS_HeapYS_Eval,
     heap.collapse HeapXS_HeapYS_Eval HeapXSYS_Eval),
-  
+
   heap.open HeapX_HeapXSYS_Eval (pfun [X] [OldXDef] HeapXSYS_Eval =>
     heap.open HeapXSYS_Eval (pfun XSYS DefsRest Eval =>
       heap.apply HeapXUpdated_HeapXSYS_Eval [X] [Eval] HeapXSYS_Eval)),
 
   heap.collapse HeapXUpdated_HeapXSYS_Eval HeapXXSYS_Eval,
   heap.extract HeapXXSYS_Eval Heap0_Body0 Heap0_Heap1_Body'.
+*)
+
+eval (Heap0_Body0) (Heap0_Heap1_Body')
+  when heap.open Heap0_Body0 (pfun XS Defs (var X) => success) :-
+
+  heap.open Heap0_Body0 (pfun XS Defs (var X) => index_of X XIndex),
+  heap.bring_to_top XIndex Heap0_Body0 Heap0'_Body0,
+
+  heap.openmany [Heap0'_Body0, Heap0'_E] (pfun (X :: XS) (XDef :: Defs) [var X, XDef] => success),
+  heap.extract Heap0'_E (heap (bind XName (fun x => body (Rest x)))) HeapX_HeapXS_E,
+
+  heap.openmany [HeapX_HeapXS_E, HeapX_HeapXSYS_Eval] (pfun [X] [XDef] [HeapXS_E, HeapXSYS_Eval] => [HeapXS_HeapYS_Eval]
+    eval HeapXS_E HeapXS_HeapYS_Eval,
+    heap.collapse HeapXS_HeapYS_Eval HeapXSYS_Eval),
+
+  heap.open HeapX_HeapXSYS_Eval (pfun [X] [OldXDef] HeapXSYS_Eval =>
+    heap.open HeapXSYS_Eval (pfun XSYS DefsRest Eval =>
+      heap.apply HeapXUpdated_HeapXSYS_Eval [X] [Eval] HeapXSYS_Eval)),
+
+  heap.collapse HeapXUpdated_HeapXSYS_Eval HeapXXSYS_Eval,
+  heap.unbring_to_top XIndex HeapXXSYS_Eval Heap0YS_Eval,
+  heap.extract Heap0YS_Eval Heap0_Body0 Heap0_Heap1_Body'.
+
+(*
+   Γ, x1 |-> e1 ... xn |-> en : e ⇓ Δ : z
+  —————————————-—————————————————————------
+  Γ : let x1 = e1 ... xn = en in e ⇓ Δ : z
+
+*)
+
+eval (Heap0_Body0) (Heap0_Heap12_Body')
+  when heap.open Heap0_Body0 (pfun XS Defs (let YS_Body) => success) :-
+
+  heap.open Heap0_Body0 (pfun XS XSDefs (let YS_E) =>
+    bindmany.open YS_E (pfun YS (YSDefs, E) => [XSYS XSYSDefs]
+      append XS YS XSYS,
+      append XSDefs YSDefs XSYSDefs,
+      heap.apply Heap01_E XSYS XSYSDefs E)),
+
+  eval Heap01_E Heap01_Heap2_Res,
+  heap.collapse Heap01_Heap2_Res Heap012_Res,
+  heap.extract Heap012_Res Heap0_Body0 Heap0_Heap12_Body'.
 
 maintests : testsuite. %testsuite maintests.
 
@@ -284,3 +352,5 @@ maintests : testsuite. %testsuite maintests.
 >> eval (heap (bind "x" (fun x => (body ([binop plus (intconst 10) (intconst 5)], binop plus (var x) (var x) ))))) X ?
 >> Yes:
 >> X := heap (bind "x" (fun x => body (tuple [ (intconst 15) ] (heap (body (tuple [  ] (intconst 30))))))).
+
+eval (heap (body ([], let (bind "u" (fun u => bind "v" (fun v => body ([binop plus (intconst 2) (intconst 3), binop plus (var u) (intconst 1)], binop plus (var v) (var v)))))))) X ?

--- a/examples/small/lazyeval.makam
+++ b/examples/small/lazyeval.makam
@@ -171,6 +171,10 @@ maintests : testsuite. %testsuite maintests.
 >> Yes:
 >> X := heap (body (tuple [  ] (intconst 15))).
 
+>> eval (heap (body ([], binop plus (let (bind "u" (fun u => body([intconst 6], var u)) )) (intconst 14)  ))) X ?
+>> Yes:
+>> X := heap (bind "u" (fun u => body (tuple [ (intconst 6) ] (intconst 20)))).
+
 >> eval (heap (bind "x" (fun x => (body ([intconst 10], var x))))) X ?
 >> Yes:
 >> X := heap (bind "x" (fun x => body (tuple [ (intconst 10) ] (intconst 10)))).

--- a/examples/small/lazyeval.makam
+++ b/examples/small/lazyeval.makam
@@ -50,16 +50,6 @@ split N (X :: XS) (X :: Pre) Post :-
   plus 1 N' N,
   split N' XS Pre Post.
 
-bring_to_top : int -> list A -> list A -> prop.
-bring_to_top Index XS (X :: XS') :-
-  split Index XS XSPre (X :: XSPost),
-  append XSPre XSPost XS'.
-
-unbring_to_top : int -> list A -> list A -> prop.
-unbring_to_top Index (X :: XS) XS' :-
-  split Index XS XSPre XSPost,
-  append XSPre (X :: XSPost) XS'.
-
 nth : list A -> int -> A -> prop.
 nth L N E :-
   split N L _ (E :: _).
@@ -119,6 +109,12 @@ apply (heap (bind Name Rest)) (X :: XS) Defs Body :-
   unless (nameofvar X Name) (success),
   apply (heap (Rest X)) XS Defs Body.
 
+apply_needed : heap A -> list var -> A -> prop.
+apply_needed (heap (body (_, Body))) _ Body.
+apply_needed (heap (bind Name Rest)) (X :: XS) Body :-
+  unless (nameofvar X Name) (success),
+  apply_needed (heap (Rest X)) XS Body.
+
 collapse : heap (heap A) -> heap A -> prop.
 extract : heap A -> heap B -> heap (heap A) -> prop.
 
@@ -136,22 +132,6 @@ extract Heap HeapRef Heap' :-
     list.split N ASBSDefs ASDefs BSDefs,
     heap.apply Heap' AS ASDefs Heap'',
     heap.apply Heap'' BS BSDefs Body).
-
-bring_to_top : int -> heap A -> heap A -> prop.
-bring_to_top Index Heap Heap' :-
-  heap.open Heap (pfun XS Defs Body => [XS' Defs']
-    list.bring_to_top Index XS XS',
-    list.bring_to_top Index Defs Defs',
-    heap.apply Heap' XS' Defs' Body
-  ).
-
-unbring_to_top : int -> heap A -> heap A -> prop.
-unbring_to_top Index Heap Heap' :-
-  heap.open Heap (pfun XS Defs Body => [XS' Defs']
-    list.unbring_to_top Index XS XS',
-    list.unbring_to_top Index Defs Defs',
-    heap.apply Heap' XS' Defs' Body
-  ).
 
 tests : testsuite. %testsuite tests.
 
@@ -180,13 +160,7 @@ tests : testsuite. %testsuite tests.
 
 %end.
 
-eval : heap expr -> heap (heap expr) -> prop.
-
-return : heap expr -> heap (heap expr) -> prop.
-
-return Heap Heap' :-
-  heap.pair Heap Heap' Heap'',
-  heap.open Heap'' (pfun XS Defs (Body, heap (body ([], Body))) => success).
+eval : heap expr -> heap expr -> prop.
 
 (*
 
@@ -197,7 +171,7 @@ return Heap Heap' :-
 
 eval (Heap_Body) Result
     when heap.open Heap_Body (pfun XS Defs (lam X_E) => success) :-
-  return Heap_Body Result.
+  eq Heap_Body Result.
 
 (*
 
@@ -207,23 +181,17 @@ eval (Heap_Body) Result
 
 *)
 
-eval (Heap0_Body0) (Heap0_Heap12_Body')
+eval (Heap0_Body0) (Heap2_Body2)
   when heap.open Heap0_Body0 (pfun XS Defs (app E X) => success) :-
 
-  heap.openmany [Heap0_Body0, Heap0_Fun] (pfun XS Defs [app E X, Fun] => eq Fun E),
+  heap.open Heap0_Body0 (pfun XS Defs (app E X) =>
+    heap.apply Heap0_Fun XS Defs E),
+  eval Heap0_Fun Heap1_Body1,
 
-  eval Heap0_Fun Heap0_Heap1_Body1,
-  heap.openmany [Heap0_Heap1_Body1, Heap0_Heap1_Body2]
-    (pfun XS Defs [Heap1_Body1, Heap1_Body2] => [Unused E X]
-    heap.apply Heap0_Body0 XS Unused (app E X),
-    heap.openmany [Heap1_Body1, Heap1_Body2]
-      (pfun XS' Defs' [lam Y_E', Body2] =>
-        eq Body2 (Y_E' X))),
-
-  heap.collapse Heap0_Heap1_Body2 Heap01_Body2,
-  eval Heap01_Body2 Heap01_Heap2_Body',
-  heap.collapse Heap01_Heap2_Body' Heap012_Body',
-  heap.extract Heap012_Body' Heap0_Body0 Heap0_Heap12_Body'.
+  heap.open Heap1_Body1 (pfun XS Defs (lam Y_E') => [E X]
+    heap.apply_needed Heap0_Body0 XS (app E X),
+    heap.apply Heap1_Body2 XS Defs (Y_E' X)),
+  eval Heap1_Body2 Heap2_Body2.
 
 
 (*
@@ -235,7 +203,7 @@ eval (Heap0_Body0) (Heap0_Heap12_Body')
 
 eval (Heap_Body) Result
     when heap.open Heap_Body (pfun XS Defs (intconst N) => success) :-
-  return Heap_Body Result.
+  eq Result Heap_Body.
 
 (*
 
@@ -245,29 +213,27 @@ eval (Heap_Body) Result
 
 *)
 
-eval (Heap0_Body0) (Heap0_Heap12_Body')
+eval (Heap0_Body0) (Heap2_Result)
   when heap.open Heap0_Body0 (pfun XS Defs (binop OP E1 E2) => success) :-
 
-  heap.openmany [Heap0_Body0, Heap0_E1, Heap0_E2] (pfun XS Defs [binop OP E1 E2, E1, E2] => eq OP OP_),
+  heap.open Heap0_Body0 (pfun XS Defs (binop OP E1 E2) =>
+    eq OP_ OP,
+    heap.apply Heap0_E1 XS Defs E1),
+  eval Heap0_E1 Heap1_V1,
 
-  eval Heap0_E1 Heap0_Heap1_Eval1,
+  heap.open Heap1_V1 (pfun XS Defs (intconst N1) => [OP E1 E2]
+    eq N1 N1_,
+    heap.apply_needed Heap0_Body0 XS (binop OP E1 E2),
+    heap.apply Heap1_E2 XS Defs E2),
+  eval Heap1_E2 Heap2_V2,
 
-  heap.openmany [Heap0_Heap1_Eval1, Heap0_Heap1_Body2]
-    (pfun XS Defs [Heap1_Eval1, Heap1_Body2] => [Unused E2]
-    heap.apply Heap0_E2 XS Unused E2,
-    heap.openmany [Heap1_Eval1, Heap1_Body2]
-      (pfun XS' Defs' [intconst N1, Body2] =>
-        eq N1 N1_, eq Body2 E2)),
+  heap.open Heap2_V2 (pfun XS Defs (intconst N2) =>
+    eq N2 N2_),
+  
+  OP_ N1_ N2_ N3,
 
-  heap.collapse Heap0_Heap1_Body2 Heap01_Body2,
-  eval Heap01_Body2 Heap01_Heap2_Eval2,
-  heap.collapse Heap01_Heap2_Eval2 Heap012_Eval2,
-
-  heap.openmany [Heap012_Eval2, Heap012_Result] (pfun XS012 Defs012 [intconst N2, intconst N3] =>
-    OP_ N1_ N2 N3
-  ),
-
-  heap.extract Heap012_Result Heap0_Body0 Heap0_Heap12_Body'.
+  heap.open Heap2_V2 (pfun XS Defs V2 =>
+    heap.apply Heap2_Result XS Defs (intconst N3)).
 
 (*
            Γ : e ⇓ Δ : z
@@ -278,20 +244,18 @@ eval (Heap0_Body0) (Heap0_Heap12_Body')
 
 *)
 
-eval (Heap0_Body0) (Heap0_Heap1_Body')
+eval (Heap0_Body0) (Heap2_Val)
   when heap.open Heap0_Body0 (pfun XS Defs (var X) => success) :-
 
-  heap.openmany [Heap0_Body0, Heap0_E] (pfun XS Defs [var X, E] =>
+  heap.open Heap0_Body0 (pfun XS Defs (var X) => [E]
     index_of X N,
-    list.nth Defs N E),
+    list.nth Defs N E,
+    heap.apply Heap0_E XS Defs E),
 
-  eval Heap0_E Heap0Upd_Heap1_Eval,
-  heap.collapse Heap0Upd_Heap1_Eval Heap0Upd1_Eval,
-  heap.open Heap0Upd1_Eval (pfun XS Defs Eval => [Defs']
-    list.update_nth Defs N Eval Defs',
-    heap.apply Heap0UpdUpd1_Eval XS Defs' Eval),
-
-  heap.extract Heap0UpdUpd1_Eval Heap0_Body0 Heap0_Heap1_Body'.
+  eval Heap0_E Heap1_Val,
+  heap.open Heap1_Val (pfun XS Defs Val => [Defs']
+    list.update_nth Defs N Val Defs',
+    heap.apply Heap2_Val XS Defs' Val).
 
 (*
    Γ, x1 |-> e1 ... xn |-> en : e ⇓ Δ : z
@@ -300,45 +264,43 @@ eval (Heap0_Body0) (Heap0_Heap1_Body')
 
 *)
 
-eval (Heap0_Body0) (Heap0_Heap12_Body')
+eval (Heap0_Body0) (Heap2_V)
   when heap.open Heap0_Body0 (pfun XS Defs (let YS_Body) => success) :-
 
   heap.open Heap0_Body0 (pfun XS XSDefs (let YS_E) =>
     bindmany.open YS_E (pfun YS (YSDefs, E) => [XSYS XSYSDefs]
       append XS YS XSYS,
       append XSDefs YSDefs XSYSDefs,
-      heap.apply Heap01_E XSYS XSYSDefs E)),
+      heap.apply Heap1_E XSYS XSYSDefs E)),
 
-  eval Heap01_E Heap01_Heap2_Res,
-  heap.collapse Heap01_Heap2_Res Heap012_Res,
-  heap.extract Heap012_Res Heap0_Body0 Heap0_Heap12_Body'.
+  eval Heap1_E Heap2_V.
 
 maintests : testsuite. %testsuite maintests.
 
 >> eval (heap (body ([], binop plus (intconst 10) (intconst 5)))) X ?
 >> Yes:
->> X := heap (body (tuple [  ] (heap (body (tuple [  ] (intconst 15)))))).
+>> X := heap (body (tuple [  ] (intconst 15))).
 
 >> eval (heap (bind "x" (fun x => (body ([intconst 10], var x))))) X ?
 >> Yes:
->> X := heap (bind "x" (fun x => body (tuple [ (intconst 10) ] (heap (body (tuple [  ] (intconst 10))))))).
+>> X := heap (bind "x" (fun x => body (tuple [ (intconst 10) ] (intconst 10)))).
 
 >> eval (heap (bind "x" (fun x => (body ([binop plus (intconst 10) (intconst 5)], var x))))) X ?
 >> Yes:
->> X := heap (bind "x" (fun x => body (tuple [ (intconst 15) ] (heap (body (tuple [  ] (intconst 15))))))).
+>> X := heap (bind "x" (fun x => body (tuple [ (intconst 15) ] (intconst 15)))).
 
 >> eval (heap (bind "x" (fun x => (body ([intconst 10], binop plus (intconst 10) (var x) ))))) X ?
 >> Yes:
->> X := heap (bind "x" (fun x => body (tuple [ (intconst 10) ] (heap (body (tuple [  ] (intconst 20))))))).
+>> X := heap (bind "x" (fun x => body (tuple [ (intconst 10) ] (intconst 20)))).
 
 >> eval (heap (bind "x" (fun x => (body ([binop plus (intconst 10) (intconst 5)], binop plus (intconst 10) (var x) ))))) X ?
 >> Yes:
->> X := heap (bind "x" (fun x => body (tuple [ (intconst 15) ] (heap (body (tuple [  ] (intconst 25))))))).
+>> X := heap (bind "x" (fun x => body (tuple [ (intconst 15) ] (intconst 25)))).
 
 >> eval (heap (bind "x" (fun x => (body ([binop plus (intconst 10) (intconst 5)], binop plus (var x) (var x) ))))) X ?
 >> Yes:
->> X := heap (bind "x" (fun x => body (tuple [ (intconst 15) ] (heap (body (tuple [  ] (intconst 30))))))).
+>> X := heap (bind "x" (fun x => body (tuple [ (intconst 15) ] (intconst 30)))).
 
 >> eval (heap (body ([], let (bind "u" (fun u => bind "v" (fun v => body ([binop plus (intconst 2) (intconst 3), binop plus (var u) (intconst 1)], binop plus (var v) (var v)))))))) X ?
 >> Yes:
->> X := heap (body (tuple [  ] (heap (bind "u" (fun u => bind "v" (fun v => body (tuple [ (intconst 5), (intconst 6) ] (intconst 12)))))))).
+>> X := heap (bind "u" (fun u => bind "v" (fun v => body (tuple [ (intconst 5), (intconst 6) ] (intconst 12))))).

--- a/examples/small/lazyeval.makam
+++ b/examples/small/lazyeval.makam
@@ -63,22 +63,30 @@ open (heap XS_DefsBody) P :-
 pair, pair_ : heap A -> heap B -> heap (A * B) -> prop.
 pair A B C :- once(pair_ A B C).
 pair_ (heap (body (Defs, Body1))) (heap (body (Defs, Body2)))
-     (heap (body (Defs, (Body1, Body2)))).
+      (heap (body (Defs, (Body1, Body2)))).
 
 pair_ (heap (bind Name F)) (heap (bind Name F')) (heap (bind Name F'')) :-
   (x:A -> pair_ (heap (F x)) (heap (F' x)) (heap (F'' x))).
 
 many : [A] heaplist A -> heap (hlist A) -> prop.
+many_aux : [Head Tail] heap Head -> heaplist Tail -> heap (hlist Tail) -> prop.
 
-many [Heap] Heap' :-
-  pair Heap Heap' Heap'',
-  open Heap'' (pfun XS Defs (Body, [Body]) => success).
-
-many (Heap :: Heaps) HeapAll when not(dyn.eq Heaps []) :-
+many (Heap :: Heaps) Result :-
+  many_aux Heap Heaps Heaps',
   pair Heap Heaps' Heaps'',
-  pair Heaps'' HeapAll Heaps''',
-  open Heaps''' (pfun XS Defs ((BodyHD, BodyTL), (BodyHD :: BodyTL)) => success),
-  many Heaps Heaps'.
+  pair Heaps'' Result Heaps''',
+  open Heaps''' (pfun XS Defs ((HDBody, TLBody), (HDBody :: TLBody)) => success).
+
+many_aux Heap [] Heap' :-
+  pair Heap Heap' Heap'',
+  open Heap'' (pfun XS Defs (Unused, []) => success).
+
+many_aux Heap (HDHeap :: TLHeap) HeapAll :-
+  pair Heap HDHeap HDHeap',
+  many_aux Heap TLHeap TLHeap',
+  pair HDHeap' TLHeap' Heap',
+  pair Heap' HeapAll Heap'',
+  open Heap'' (pfun XS Defs (((Unused1, BodyHD), BodyTL), (BodyHD :: BodyTL)) => success).
 
 openmany : heaplist A -> (list var -> list expr -> hlist A -> prop) -> prop.
 openmany Heaps P :- many Heaps Heaps', open Heaps' P.
@@ -114,6 +122,12 @@ tests : testsuite. %testsuite tests.
 >> Yes:
 >> X := heap (bind "a" (fun a => bind "b" (fun b => body ([var a, var b], [var a])))).
 
+>> heap.many [heap (bind "a" (fun a => body ([var a], var a))), H1, H2] X ?
+>> Yes:
+>> X := heap (bind "a" (fun a => body (tuple [ (var a) ] [ (var a), #Body1, #Body2 ]))),
+>> H1 := heap (bind "a" (fun a => body (tuple [ (var a) ] #Body1))),
+>> H2 := heap (bind "a" (fun a => body (tuple [ (var a) ] #Body2))).
+
 >> heap.many [heap (bind "a" (fun a => bind "b" (fun b => body ([var a, var b], var a)))),
            heap (bind "a" (fun a => bind "b" (fun b => body ([var a, var b], var b))))] X ?
 >> Yes:
@@ -131,6 +145,12 @@ tests : testsuite. %testsuite tests.
 
 eval : heap expr -> heap (heap expr) -> prop.
 
+return : heap expr -> heap (heap expr) -> prop.
+
+return Heap Heap' :-
+  heap.pair Heap Heap' Heap'',
+  heap.open Heap'' (pfun XS Defs (Body, heap (body ([], Body))) => success).
+
 (*
 
   ———————————————————
@@ -138,8 +158,9 @@ eval : heap expr -> heap (heap expr) -> prop.
 
 *)
 
-eval (Heap_Body) (heap (body ([], Heap_Body)))
-  when heap.open Heap_Body (pfun XS Defs (lam X_E) => success).
+eval (Heap_Body) Result
+    when heap.open Heap_Body (pfun XS Defs (lam X_E) => success) :-
+  return Heap_Body Result.
 
 (*
 
@@ -174,8 +195,9 @@ eval (Heap0_Body0) (Heap0_Heap12_Body')
   
 *)
 
-eval (Heap_Body) (heap (body ([], Heap_Body)))
-  when heap.open Heap_Body (pfun XS Defs (intconst N) => success).
+eval (Heap_Body) Result
+    when heap.open Heap_Body (pfun XS Defs (intconst N) => success) :-
+  return Heap_Body Result.
 
 (*
 
@@ -191,6 +213,7 @@ eval (Heap0_Body0) (Heap0_Heap12_Body')
   heap.openmany [Heap0_Body0, Heap0_E1, Heap0_E2] (pfun XS Defs [binop OP E1 E2, E1, E2] => eq OP OP_),
 
   eval Heap0_E1 Heap0_Heap1_Eval1,
+
   heap.openmany [Heap0_E2, Heap0_Heap1_Eval1, Heap0_Heap1_Body2]
     (pfun XS Defs [E2, Heap1_Eval1, Heap1_Body2] =>
     heap.openmany [Heap1_Eval1, Heap1_Body2]
@@ -245,4 +268,10 @@ maintests : testsuite. %testsuite maintests.
 >> Yes:
 >> X := heap (bind "x" (fun x => body (tuple [ (intconst 15) ] (heap (body (tuple [  ] (intconst 15))))))).
 
-eval (heap (bind "x" (fun x => (body ([intconst 10], binop plus (intconst 10) (var x) ))))) X ?
+>> eval (heap (bind "x" (fun x => (body ([intconst 10], binop plus (intconst 10) (var x) ))))) X ?
+>> Yes:
+>> X := heap (bind "x" (fun x => body (tuple [ (intconst 10) ] (heap (body (tuple [  ] (intconst 20))))))).
+
+>> eval (heap (bind "x" (fun x => (body ([binop plus (intconst 10) (intconst 5)], binop plus (intconst 10) (var x) ))))) X ?
+>> Yes:
+>> X := heap (bind "x" (fun x => body (tuple [ (intconst 15) ] (heap (body (tuple [  ] (intconst 25))))))).

--- a/examples/small/lazyeval.makam
+++ b/examples/small/lazyeval.makam
@@ -24,42 +24,7 @@ binop : (int -> int -> int -> prop) -> expr -> expr -> expr.
 *)
 
 heap : type -> type.
-
 heap : bindmany var (list expr * A) -> heap A.
-
-index_of : var -> int -> prop.
-
-assumeindex : list var -> prop -> prop.
-assumeindex_aux : int -> list var -> prop -> prop.
-assumeindex_aux _ [] P when P.
-assumeindex_aux N (X :: XS) P when
-  plus N 1 N',
-  assumeindex_aux N' XS {prop| (index_of X N -> P) |}.
-
-assumeindex L P when assumeindex_aux 0 L P.
-
-heaplist : type -> type.
-nil : heaplist t_nil.
-cons : heap HD -> heaplist TL -> heaplist (t_cons HD TL).
-
-%extend list.
-
-split : int -> list A -> list A -> list A -> prop.
-split 0 Post [] Post.
-split N (X :: XS) (X :: Pre) Post :-
-  plus 1 N' N,
-  split N' XS Pre Post.
-
-nth : list A -> int -> A -> prop.
-nth L N E :-
-  split N L _ (E :: _).
-
-update_nth : list A -> int -> A -> list A -> prop.
-update_nth L N E L' :-
-  split N L Pre (_ :: Post),
-  split N L' Pre (E :: Post).
-
-%end.
 
 %extend heap.
 
@@ -67,41 +32,7 @@ open : heap A -> (list var -> list expr -> A -> prop) -> prop.
 
 open (heap XS_DefsBody) P :-
   bindmany.open XS_DefsBody (pfun XS (Defs, Body) =>
-    assumeindex XS (P XS Defs Body)).
-
-(* used as a marker to denote which definitions to keep *)
-keep : heap A -> heap A.
-
-pair, pair_ : heap A -> heap B -> heap (A * B) -> prop.
-pair A B C :- once(pair_ A B C).
-pair_ (heap (body (Defs, Body1))) (heap (body (Defs, Body2)))
-      (heap (body (Defs, (Body1, Body2)))).
-
-pair_ (heap (bind Name F)) (heap (bind Name F')) (heap (bind Name F'')) :-
-  (x:A -> pair_ (heap (F x)) (heap (F' x)) (heap (F'' x))).
-
-many : [A] heaplist A -> heap (hlist A) -> prop.
-many_aux : [Head Tail] heap Head -> heaplist Tail -> heap (hlist Tail) -> prop.
-
-many (Heap :: Heaps) Result :-
-  many_aux Heap Heaps Heaps',
-  pair Heap Heaps' Heaps'',
-  pair Heaps'' Result Heaps''',
-  open Heaps''' (pfun XS Defs ((HDBody, TLBody), (HDBody :: TLBody)) => success).
-
-many_aux Heap [] Heap' :-
-  pair Heap Heap' Heap'',
-  open Heap'' (pfun XS Defs (Unused, []) => success).
-
-many_aux Heap (HDHeap :: TLHeap) HeapAll :-
-  pair Heap HDHeap HDHeap',
-  many_aux Heap TLHeap TLHeap',
-  pair HDHeap' TLHeap' Heap',
-  pair Heap' HeapAll Heap'',
-  open Heap'' (pfun XS Defs (((Unused1, BodyHD), BodyTL), (BodyHD :: BodyTL)) => success).
-
-openmany : heaplist A -> (list var -> list expr -> hlist A -> prop) -> prop.
-openmany Heaps P :- many Heaps Heaps', open Heaps' P.
+    P XS Defs Body).
 
 apply : heap A -> list var -> list expr -> A -> prop.
 apply (heap (body (Defs, Body))) [] Defs Body.
@@ -114,49 +45,6 @@ apply_needed (heap (body (_, Body))) _ Body.
 apply_needed (heap (bind Name Rest)) (X :: XS) Body :-
   unless (nameofvar X Name) (success),
   apply_needed (heap (Rest X)) XS Body.
-
-collapse : heap (heap A) -> heap A -> prop.
-extract : heap A -> heap B -> heap (heap A) -> prop.
-
-collapse (heap AS_BS_Body) ASBS_Body :-
-  bindmany.open AS_BS_Body (pfun AS (ADefs, heap BS_Body) =>
-    bindmany.open BS_Body (pfun BS (BDefs, Body) => [ASBS ABDefs]
-      append AS BS ASBS,
-      append ADefs BDefs ABDefs,
-      heap.apply ASBS_Body ASBS ABDefs Body)).
-
-extract Heap HeapRef Heap' :-
-  heap.open HeapRef (pfun AS Defs Body => length AS N),
-  heap.open Heap (pfun ASBS ASBSDefs Body => [AS BS ASDefs BSDefs Heap'']
-    list.split N ASBS AS BS,
-    list.split N ASBSDefs ASDefs BSDefs,
-    heap.apply Heap' AS ASDefs Heap'',
-    heap.apply Heap'' BS BSDefs Body).
-
-tests : testsuite. %testsuite tests.
-
->> heap.many [heap (bind "a" (fun a => bind "b" (fun b => body ([var a, var b], var a))))] X ?
->> Yes:
->> X := heap (bind "a" (fun a => bind "b" (fun b => body ([var a, var b], [var a])))).
-
->> heap.many [heap (bind "a" (fun a => body ([var a], var a))), H1, H2] X ?
->> Yes:
->> X := heap (bind "a" (fun a => body (tuple [ (var a) ] [ (var a), #Body1, #Body2 ]))),
->> H1 := heap (bind "a" (fun a => body (tuple [ (var a) ] #Body1))),
->> H2 := heap (bind "a" (fun a => body (tuple [ (var a) ] #Body2))).
-
->> heap.many [heap (bind "a" (fun a => bind "b" (fun b => body ([var a, var b], var a)))),
-           heap (bind "a" (fun a => bind "b" (fun b => body ([var a, var b], var b))))] X ?
->> Yes:
->> X := heap (bind "a" (fun a => bind "b" (fun b => body ([var a, var b], [var a, var b])))).
-
->> heap.collapse (heap (bind "a" (fun a => body ([var a], heap (bind "b" (fun b => body ([var b], [var b, var a]))))))) X ?
->> Yes:
->> X := heap (bind "a" (fun a => bind "b" (fun b => body (tuple [ (var a), (var b) ] [ (var b), (var a) ])))).
-
->> heap.extract (heap (bind "a" (fun a => bind "b" (fun b => body (tuple [ (var a), (var b) ] [ (var b), (var a) ]))))) (heap (bind "a" (fun a => body ([app (var a) a], 1)))) X ?
->> Yes:
->> X := heap (bind "a" (fun a => body (tuple [ (var a) ] (heap (bind "b" (fun b => body (tuple [ (var b) ] [ (var b), (var a) ]))))))).
 
 %end.
 
@@ -248,7 +136,7 @@ eval (Heap0_Body0) (Heap2_Val)
   when heap.open Heap0_Body0 (pfun XS Defs (var X) => success) :-
 
   heap.open Heap0_Body0 (pfun XS Defs (var X) => [E]
-    index_of X N,
+    list.index_of (pfun Y => eq Y X) XS N,
     list.nth Defs N E,
     heap.apply Heap0_E XS Defs E),
 
@@ -274,6 +162,8 @@ eval (Heap0_Body0) (Heap2_V)
       heap.apply Heap1_E XSYS XSYSDefs E)),
 
   eval Heap1_E Heap2_V.
+
+(* and now for some tests *)
 
 maintests : testsuite. %testsuite maintests.
 

--- a/examples/small/lazyeval.makam
+++ b/examples/small/lazyeval.makam
@@ -1,0 +1,248 @@
+(* An implementation of the standard Launchbury semantics
+   for call-by-need evaluation, using an explicit heap. *)
+
+expr : type.
+var : type.
+
+lam : (var -> expr) -> expr.
+
+(* Arguments to applications need to be variables *)
+app : expr -> var -> expr.
+
+var : var -> expr.
+
+let : bindmany var (list expr * expr) -> expr.
+
+intconst : int -> expr.
+
+binop : (int -> int -> int -> prop) -> expr -> expr -> expr.
+
+(* now let's model heaps. In this semantics, heaps are
+   variable binding - expression definition pairs. In Makam,
+   we will model them as a number of bindings followed by
+   their definitions in the same order. 
+*)
+
+heap : type -> type.
+
+heap : bindmany var (list expr * A) -> heap A.
+
+index_of : var -> int -> prop.
+
+assumeindex : list var -> prop -> prop.
+assumeindex_aux : int -> list var -> prop -> prop.
+assumeindex_aux _ [] P when P.
+assumeindex_aux N (X :: XS) P when
+  plus N 1 N',
+  assumeindex_aux N' XS {prop| (index_of X N -> P) |}.
+
+assumeindex L P when assumeindex_aux 0 L P.
+
+heaplist : type -> type.
+nil : heaplist t_nil.
+cons : heap HD -> heaplist TL -> heaplist (t_cons HD TL).
+
+%extend list.
+
+split : int -> list A -> list A -> list A -> prop.
+split 0 Post [] Post.
+split N (X :: XS) (X :: Pre) Post :-
+  plus 1 N' N,
+  split N' XS Pre Post.
+
+%end.
+
+%extend heap.
+
+open : heap A -> (list var -> list expr -> A -> prop) -> prop.
+
+open (heap XS_DefsBody) P :-
+  bindmany.open XS_DefsBody (pfun XS (Defs, Body) =>
+    assumeindex XS (P XS Defs Body)).
+
+pair, pair_ : heap A -> heap B -> heap (A * B) -> prop.
+pair A B C :- once(pair_ A B C).
+pair_ (heap (body (Defs, Body1))) (heap (body (Defs, Body2)))
+     (heap (body (Defs, (Body1, Body2)))).
+
+pair_ (heap (bind Name F)) (heap (bind Name F')) (heap (bind Name F'')) :-
+  (x:A -> pair_ (heap (F x)) (heap (F' x)) (heap (F'' x))).
+
+many : [A] heaplist A -> heap (hlist A) -> prop.
+
+many [Heap] Heap' :-
+  pair Heap Heap' Heap'',
+  open Heap'' (pfun XS Defs (Body, [Body]) => success).
+
+many (Heap :: Heaps) HeapAll when not(dyn.eq Heaps []) :-
+  pair Heap Heaps' Heaps'',
+  pair Heaps'' HeapAll Heaps''',
+  open Heaps''' (pfun XS Defs ((BodyHD, BodyTL), (BodyHD :: BodyTL)) => success),
+  many Heaps Heaps'.
+
+openmany : heaplist A -> (list var -> list expr -> hlist A -> prop) -> prop.
+openmany Heaps P :- many Heaps Heaps', open Heaps' P.
+
+apply : heap A -> list var -> list expr -> A -> prop.
+apply (heap (body (Defs, Body))) [] Defs Body.
+apply (heap (bind Name Rest)) (X :: XS) Defs Body :-
+  unless (nameofvar X Name) (success),
+  apply (heap (Rest X)) XS Defs Body.
+
+collapse : heap (heap A) -> heap A -> prop.
+extract : heap A -> heap B -> heap (heap A) -> prop.
+
+collapse (heap AS_BS_Body) ASBS_Body :-
+  bindmany.open AS_BS_Body (pfun AS (ADefs, heap BS_Body) =>
+    bindmany.open BS_Body (pfun BS (BDefs, Body) => [ASBS ABDefs]
+      append AS BS ASBS,
+      append ADefs BDefs ABDefs,
+      heap.apply ASBS_Body ASBS ABDefs Body)).
+
+extract (heap ASBS_Body) (heap AS_Rest) (heap AS_BS_Body) :-
+  bindmany.pair AS_Rest AS_BS_Body Both,
+  bindmany.open Both (pfun AS (Rest, (ADefs, Heap_BS_Body)) => [BS_Body]
+    bindmany.applysome ASBS_Body AS BS_Body,
+    bindmany.open BS_Body (pfun BS (ABDefs, Body) => [BDefs]
+      heap.apply Heap_BS_Body BS BDefs Body,
+      length AS N,
+      list.split N ABDefs ADefs BDefs)).
+
+tests : testsuite. %testsuite tests.
+
+>> heap.many [heap (bind "a" (fun a => bind "b" (fun b => body ([var a, var b], var a))))] X ?
+>> Yes:
+>> X := heap (bind "a" (fun a => bind "b" (fun b => body ([var a, var b], [var a])))).
+
+>> heap.many [heap (bind "a" (fun a => bind "b" (fun b => body ([var a, var b], var a)))),
+           heap (bind "a" (fun a => bind "b" (fun b => body ([var a, var b], var b))))] X ?
+>> Yes:
+>> X := heap (bind "a" (fun a => bind "b" (fun b => body ([var a, var b], [var a, var b])))).
+
+>> heap.collapse (heap (bind "a" (fun a => body ([var a], heap (bind "b" (fun b => body ([var b], [var b, var a]))))))) X ?
+>> Yes:
+>> X := heap (bind "a" (fun a => bind "b" (fun b => body (tuple [ (var a), (var b) ] [ (var b), (var a) ])))).
+
+>> heap.extract (heap (bind "a" (fun a => bind "b" (fun b => body (tuple [ (var a), (var b) ] [ (var b), (var a) ]))))) (heap (bind "a" (fun a => body ([app (var a) a], 1)))) X ?
+>> Yes:
+>> X := heap (bind "a" (fun a => body (tuple [ (var a) ] (heap (bind "b" (fun b => body (tuple [ (var b) ] [ (var b), (var a) ]))))))).
+
+%end.
+
+eval : heap expr -> heap (heap expr) -> prop.
+
+(*
+
+  ———————————————————
+  Γ : λx.e ⇓ Γ : λx.e
+
+*)
+
+eval (Heap_Body) (heap (body ([], Heap_Body)))
+  when heap.open Heap_Body (pfun XS Defs (lam X_E) => success).
+
+(*
+
+   Γ : e ⇓ Δ : λy.e'   Δ : e'[x/y] ⇓ Θ : z
+   ————————————————————————————————————————
+              Γ : e x ⇓ Θ : z
+
+*)
+
+eval (Heap0_Body0) (Heap0_Heap12_Body')
+  when heap.open Heap0_Body0 (pfun XS Defs (app E X) => success) :-
+
+  heap.openmany [Heap0_Body0, Heap0_Fun] (pfun XS Defs [app E X, Fun] => eq Fun E),
+
+  eval Heap0_Fun Heap0_Heap1_Body1,
+  heap.openmany [Heap0_Body0, Heap0_Heap1_Body1, Heap0_Heap1_Body2]
+    (pfun XS Defs [app E X, Heap1_Body1, Heap1_Body2] =>
+    heap.openmany [Heap1_Body1, Heap1_Body2]
+      (pfun XS' Defs' [lam Y_E', Body2] =>
+        eq Body2 (Y_E' X))),
+
+  heap.collapse Heap0_Heap1_Body2 Heap01_Body2,
+  eval Heap01_Body2 Heap01_Heap2_Body',
+  heap.collapse Heap01_Heap2_Body' Heap012_Body',
+  heap.extract Heap012_Body' Heap0_Body0 Heap0_Heap12_Body'.
+
+
+(*
+
+  —————————————-
+  Γ : n ⇓ Γ : n
+  
+*)
+
+eval (Heap_Body) (heap (body ([], Heap_Body)))
+  when heap.open Heap_Body (pfun XS Defs (intconst N) => success).
+
+(*
+
+   Γ : e1 ⇓ Δ : n1     Δ : e2 ⇓ Θ : n2    OP n1 n2 = n3
+   —————————————————————————————————————————————————————
+              Γ : binop OP e1 e2 ⇓ Θ : n3
+
+*)
+
+eval (Heap0_Body0) (Heap0_Heap12_Body')
+  when heap.open Heap0_Body0 (pfun XS Defs (binop OP E1 E2) => success) :-
+
+  heap.openmany [Heap0_Body0, Heap0_E1, Heap0_E2] (pfun XS Defs [binop OP E1 E2, E1, E2] => eq OP OP_),
+
+  eval Heap0_E1 Heap0_Heap1_Eval1,
+  heap.openmany [Heap0_E2, Heap0_Heap1_Eval1, Heap0_Heap1_Body2]
+    (pfun XS Defs [E2, Heap1_Eval1, Heap1_Body2] =>
+    heap.openmany [Heap1_Eval1, Heap1_Body2]
+      (pfun XS' Defs' [intconst N1, Body2] =>
+        eq N1 N1_, eq Body2 E2)),
+
+  heap.collapse Heap0_Heap1_Body2 Heap01_Body2,
+  eval Heap01_Body2 Heap01_Heap2_Eval2,
+  heap.collapse Heap01_Heap2_Eval2 Heap012_Eval2,
+
+  heap.openmany [Heap012_Eval2, Heap012_Result] (pfun XS012 Defs012 [intconst N2, intconst N3] =>
+    OP_ N1_ N2 N3
+  ),
+
+  heap.extract Heap012_Result Heap0_Body0 Heap0_Heap12_Body'.
+
+(*
+           Γ : e ⇓ Δ : z
+  —————————————-—————————————————————
+  (Γ, x |-> e) : x ⇓ (Δ, x |-> z) : z
+  
+*)
+
+eval (Heap0_Body0) (Heap0_Heap1_Body')
+  when heap.open Heap0_Body0 (pfun (X :: XS) (XDef :: Defs) (var X) => success) :-
+
+  heap.openmany [Heap0_Body0, Heap0_E] (pfun (X :: XS) (XDef :: Defs) [var X, XDef] => success),
+  heap.extract Heap0_E (heap (bind XName (fun x => Rest x))) HeapX_HeapXS_E,
+
+  heap.openmany [HeapX_HeapXS_E, HeapX_HeapXSYS_Eval] (pfun [X] [XDef] [HeapXS_E, HeapXSYS_Eval] => [HeapXS_HeapYS_Eval]
+    eval HeapXS_E HeapXS_HeapYS_Eval,
+    heap.collapse HeapXS_HeapYS_Eval HeapXSYS_Eval),
+  
+  heap.open HeapX_HeapXSYS_Eval (pfun [X] [OldXDef] HeapXSYS_Eval =>
+    heap.open HeapXSYS_Eval (pfun XSYS DefsRest Eval =>
+      heap.apply HeapXUpdated_HeapXSYS_Eval [X] [Eval] HeapXSYS_Eval)),
+
+  heap.collapse HeapXUpdated_HeapXSYS_Eval HeapXXSYS_Eval,
+  heap.extract HeapXXSYS_Eval Heap0_Body0 Heap0_Heap1_Body'.
+
+maintests : testsuite. %testsuite maintests.
+
+>> eval (heap (body ([], binop plus (intconst 10) (intconst 5)))) X ?
+>> Yes:
+>> X := heap (body (tuple [  ] (heap (body (tuple [  ] (intconst 15)))))).
+
+>> eval (heap (bind "x" (fun x => (body ([intconst 10], var x))))) X ?
+>> Yes:
+>> X := heap (bind "x" (fun x => body (tuple [ (intconst 10) ] (heap (body (tuple [  ] (intconst 10))))))).
+
+>> eval (heap (bind "x" (fun x => (body ([binop plus (intconst 10) (intconst 5)], var x))))) X ?
+>> Yes:
+>> X := heap (bind "x" (fun x => body (tuple [ (intconst 15) ] (heap (body (tuple [  ] (intconst 15))))))).
+
+eval (heap (bind "x" (fun x => (body ([intconst 10], binop plus (intconst 10) (var x) ))))) X ?

--- a/examples/small/lazyeval.makam
+++ b/examples/small/lazyeval.makam
@@ -198,3 +198,101 @@ maintests : testsuite. %testsuite maintests.
 >> eval (heap (body ([], let (bind "u" (fun u => bind "v" (fun v => body ([binop plus (intconst 2) (intconst 3), binop plus (var u) (intconst 1)], binop plus (var v) (var v)))))))) X ?
 >> Yes:
 >> X := heap (bind "u" (fun u => bind "v" (fun v => body (tuple [ (intconst 5), (intconst 6) ] (intconst 12))))).
+
+(* constructors and pattern-matching *)
+
+constr : string -> list var -> expr.
+
+case : expr -> list (string * bindmany var expr) -> expr.
+
+(*
+  ————————————————————————————————————
+  Γ : c x_1 .. x_n ⇓ Γ : c x_1 .. x_n
+*)
+
+eval (Heap0_Body0) (Heap0_Body0)
+  when heap.open Heap0_Body0 (pfun XS Defs (constr C Vars) => success).
+
+(*
+  Γ : e ⇓ Δ : c_k x_1 .. x_mk   Δ : e_k[x_i/y_i] ⇓ Θ : z
+  ——————————————————————————————————————————————————————
+  Γ : case e of { c_i (y_1 .. y_mi . e_i) }..i ⇓ Θ : z
+*)
+
+eval (Heap0_Body0) (Heap2_Body2)
+  when heap.open Heap0_Body0 (pfun XS Defs (case E Branches) => success) :-
+
+  heap.open Heap0_Body0 (pfun XS Defs (case E Branches) =>
+    heap.apply Heap0_E XS Defs E),
+  eval Heap0_E Heap1_Scrutinee,
+
+  heap.open Heap1_Scrutinee (pfun XS Defs (constr Ck Vars) => [E Branches RestK EkSubst]
+    heap.apply_needed Heap0_Body0 XS (case E Branches),
+    list.index_of (pfun Branch => [Rest] eq Branch (Ck, Rest)) Branches N,
+    list.nth Branches N (Ck, RestK),
+    bindmany.apply RestK Vars EkSubst,
+    heap.apply Heap1_EkSubst XS Defs EkSubst),
+
+  eval Heap1_EkSubst Heap2_Body2.
+
+(* forms that normalize to the restricted grammar, to make writing the following tests easier *)
+
+app : expr -> expr -> expr.
+eval (Heap0_Body0) Result
+  when heap.open Heap0_Body0 (pfun XS Defs (app E1 E2) => success) :-
+
+  heap.open Heap0_Body0 (pfun XS Defs (app E1 E2) =>
+    heap.apply Heap0_Body1 XS Defs (let (bind _ (fun x => body ([E2], app E1 x))))
+  ),
+
+  eval Heap0_Body1 Result.
+
+constr : string -> list expr -> expr.
+eval (Heap0_Body0) Result
+  when heap.open Heap0_Body0 (pfun XS Defs (constr S ES) => success) :-
+
+  heap.open Heap0_Body0 (pfun XS Defs (constr S ES) => [YS_C YS Body]
+    heap.apply Heap0_Body1 XS Defs (let YS_C),
+    map (fun e y => success) ES YS,
+    bindmany.apply YS_C YS Body,
+    bindmany.open YS_C (pfun NewYS RealBody =>
+      eq RealBody (ES, constr S NewYS)
+    )
+  ),
+
+  eval Heap0_Body1 Result.
+
+(* predicate to isolate the body in a heap when it does not depend on the heap variables *)
+get_body : heap A -> A -> prop.
+get_body Heap Body :-
+  heap.open Heap (pfun XS Defs Body' => eq Body Body').
+
+(* recursive function, non-recursive data *)
+>> (eval (heap (body ([], let (bind "length" (fun length => body (
+      [ (* length = *)
+        lam (fun l => case (var l) [
+          ( "nil", body (intconst 0) ),
+          ( "cons", bind "x" (fun x => bind "xs" (fun xs => body (
+                    let (bind "xs_length" (fun xs_length => body ([ app (var length) xs ],
+                      binop plus (intconst 1) (var xs_length))))))) )
+        ]) ],
+        app (var length) (constr "cons" [intconst 1, constr "cons" [intconst 2, constr "nil" []]]))))))) _X, get_body _X X) ?
+>> Yes:
+>> X := intconst 2.
+
+(* recursive data, non-recursive function *)
+>> (eval (heap (body ([], let (bind "head" (fun head => bind "second" (fun second => body (
+      [ (* head = *)
+        lam (fun l => case (var l) [
+          ( "cons", bind "x" (fun x => bind "xs" (fun xs => body (var x))))
+        ]),
+        (* second = *)
+        lam (fun l => case (var l) [
+          ( "cons", bind "x" (fun x => bind "xs" (fun xs => body (app (var head) xs))))
+        ])
+     ],
+     let (bind "inf_ones" (fun inf_ones => body (
+         [ constr "cons" [intconst 1, var inf_ones] ],
+         app (var second) (constr "cons" [intconst 2, var inf_ones]))))))))))) _X, get_body _X X) ?
+>> Yes:
+>> X := intconst 1.

--- a/examples/small/lazyeval.makam
+++ b/examples/small/lazyeval.makam
@@ -60,6 +60,15 @@ unbring_to_top Index (X :: XS) XS' :-
   split Index XS XSPre XSPost,
   append XSPre (X :: XSPost) XS'.
 
+nth : list A -> int -> A -> prop.
+nth L N E :-
+  split N L _ (E :: _).
+
+update_nth : list A -> int -> A -> list A -> prop.
+update_nth L N E L' :-
+  split N L Pre (_ :: Post),
+  split N L' Pre (E :: Post).
+
 %end.
 
 %extend heap.
@@ -265,47 +274,24 @@ eval (Heap0_Body0) (Heap0_Heap12_Body')
   —————————————-—————————————————————
   (Γ, x |-> e) : x ⇓ (Δ, x |-> z) : z
 
-*)
+  here we differ in that we keep the binding for x alive in the premise
 
-(*
-eval (Heap0_Body0) (Heap0_Heap1_Body')
-  when heap.open Heap0_Body0 (pfun (X :: XS) (XDef :: Defs) (var X) => success) :-
-
-  heap.openmany [Heap0_Body0, Heap0_E] (pfun (X :: XS) (XDef :: Defs) [var X, XDef] => success),
-  heap.extract Heap0_E (heap (bind XName (fun x => body (Rest x)))) HeapX_HeapXS_E,
-
-  heap.openmany [HeapX_HeapXS_E, HeapX_HeapXSYS_Eval] (pfun [X] [XDef] [HeapXS_E, HeapXSYS_Eval] => [HeapXS_HeapYS_Eval]
-    eval HeapXS_E HeapXS_HeapYS_Eval,
-    heap.collapse HeapXS_HeapYS_Eval HeapXSYS_Eval),
-
-  heap.open HeapX_HeapXSYS_Eval (pfun [X] [OldXDef] HeapXSYS_Eval =>
-    heap.open HeapXSYS_Eval (pfun XSYS DefsRest Eval =>
-      heap.apply HeapXUpdated_HeapXSYS_Eval [X] [Eval] HeapXSYS_Eval)),
-
-  heap.collapse HeapXUpdated_HeapXSYS_Eval HeapXXSYS_Eval,
-  heap.extract HeapXXSYS_Eval Heap0_Body0 Heap0_Heap1_Body'.
 *)
 
 eval (Heap0_Body0) (Heap0_Heap1_Body')
   when heap.open Heap0_Body0 (pfun XS Defs (var X) => success) :-
 
-  heap.open Heap0_Body0 (pfun XS Defs (var X) => index_of X XIndex),
-  heap.bring_to_top XIndex Heap0_Body0 Heap0'_Body0,
+  heap.openmany [Heap0_Body0, Heap0_E] (pfun XS Defs [var X, E] =>
+    index_of X N,
+    list.nth Defs N E),
 
-  heap.openmany [Heap0'_Body0, Heap0'_E] (pfun (X :: XS) (XDef :: Defs) [var X, XDef] => success),
-  heap.extract Heap0'_E (heap (bind XName (fun x => body (Rest x)))) HeapX_HeapXS_E,
+  eval Heap0_E Heap0Upd_Heap1_Eval,
+  heap.collapse Heap0Upd_Heap1_Eval Heap0Upd1_Eval,
+  heap.open Heap0Upd1_Eval (pfun XS Defs Eval => [Defs']
+    list.update_nth Defs N Eval Defs',
+    heap.apply Heap0UpdUpd1_Eval XS Defs' Eval),
 
-  heap.openmany [HeapX_HeapXS_E, HeapX_HeapXSYS_Eval] (pfun [X] [XDef] [HeapXS_E, HeapXSYS_Eval] => [HeapXS_HeapYS_Eval]
-    eval HeapXS_E HeapXS_HeapYS_Eval,
-    heap.collapse HeapXS_HeapYS_Eval HeapXSYS_Eval),
-
-  heap.open HeapX_HeapXSYS_Eval (pfun [X] [OldXDef] HeapXSYS_Eval =>
-    heap.open HeapXSYS_Eval (pfun XSYS DefsRest Eval =>
-      heap.apply HeapXUpdated_HeapXSYS_Eval [X] [Eval] HeapXSYS_Eval)),
-
-  heap.collapse HeapXUpdated_HeapXSYS_Eval HeapXXSYS_Eval,
-  heap.unbring_to_top XIndex HeapXXSYS_Eval Heap0YS_Eval,
-  heap.extract Heap0YS_Eval Heap0_Body0 Heap0_Heap1_Body'.
+  heap.extract Heap0UpdUpd1_Eval Heap0_Body0 Heap0_Heap1_Body'.
 
 (*
    Γ, x1 |-> e1 ... xn |-> en : e ⇓ Δ : z
@@ -353,4 +339,6 @@ maintests : testsuite. %testsuite maintests.
 >> Yes:
 >> X := heap (bind "x" (fun x => body (tuple [ (intconst 15) ] (heap (body (tuple [  ] (intconst 30))))))).
 
-eval (heap (body ([], let (bind "u" (fun u => bind "v" (fun v => body ([binop plus (intconst 2) (intconst 3), binop plus (var u) (intconst 1)], binop plus (var v) (var v)))))))) X ?
+>> eval (heap (body ([], let (bind "u" (fun u => bind "v" (fun v => body ([binop plus (intconst 2) (intconst 3), binop plus (var u) (intconst 1)], binop plus (var v) (var v)))))))) X ?
+>> Yes:
+>> X := heap (body (tuple [  ] (heap (bind "u" (fun u => bind "v" (fun v => body (tuple [ (intconst 5), (intconst 6) ] (intconst 12)))))))).

--- a/js/index.html
+++ b/js/index.html
@@ -10,7 +10,7 @@
 
       var worker = new Worker('makam.js');
       var terminal = null;
-      const version = "0.7.17";
+      const version = "0.7.18";
      
       $(function() {
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "makam",
-  "version": "0.7.17",
+  "version": "0.7.18",
   "description": "The Makam metalanguage -- a tool for rapid language prototyping",
   "main": "lib/index.js",
   "scripts": {

--- a/opam/opam
+++ b/opam/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "makam"
-version: "0.7.17"
+version: "0.7.18"
 maintainer: "Antonis Stampoulis <antonis.stampoulis@gmail.com>"
 authors: [ "Antonis Stampoulis <antonis.stampoulis@gmail.com>" ]
 license: "GPL-3"

--- a/stdlib/list.makam
+++ b/stdlib/list.makam
@@ -131,4 +131,25 @@ snoc (X :: XS) Y (X :: XS_Y) :- snoc XS Y XS_Y.
 last : list A -> A -> prop.
 last [X] X.
 last (_ :: TL) X :- last TL X.
+
+split : int -> list A -> list A -> list A -> prop.
+split 0 Post [] Post.
+split N (X :: XS) (X :: Pre) Post :-
+  plus 1 N' N,
+  split N' XS Pre Post.
+
+nth : list A -> int -> A -> prop.
+nth L N E :-
+  split N L _ (E :: _).
+
+update_nth : list A -> int -> A -> list A -> prop.
+update_nth L N E L' :-
+  split N L Pre (_ :: Post),
+  split N L' Pre (E :: Post).
+
+index_of : (A -> prop) -> list A -> int -> prop.
+index_of_aux : int -> (A -> prop) -> list A -> int -> prop.
+index_of_aux I Pred (HD :: TL) N :- if (Pred HD) then eq N I else (plus I 1 I', index_of_aux I' Pred TL N).
+index_of Pred L N :- index_of_aux 0 Pred L N.
+
 %end.

--- a/toploop/version.ml
+++ b/toploop/version.ml
@@ -1,2 +1,2 @@
-let version = "0.7.17" ;;
+let version = "0.7.18" ;;
 let source_hash = "607a0d845d5a1589c492897145519d6ac2ce5ec1";;

--- a/webui/package.json
+++ b/webui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "makam-webui",
-  "version": "0.7.17",
+  "version": "0.7.18",
   "description": "CodeMirror-based WebUI for Makam",
   "main": "makam-webui-bundle.js",
   "scripts": {


### PR DESCRIPTION
Added an example that implements call-by-need semantics for the lambda calculus using an explicit heap, which maps variables to expressions.

Follows "A Natural Semantics for Lazy Evaluation" by John Launchbury in POPL 93.

Might add a couple more tests (especially one involving recursion), but opening this PR since it's at a point where this reads relatively well.

@teofr 