### PR TITLE
The `mult` primitive was wrong in some cases.

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -1,6 +1,6 @@
 OASISFormat: 0.4
 Name:        makam
-Version:     0.7.20
+Version:     0.7.21
 Synopsis:    The Makam Metalanguage -- a tool for rapid language prototyping
 Authors:     Antonis Stampoulis <antonis.stampoulis@gmail.com>
 Homepage:    http://astampoulis.github.io/

--- a/examples/lib/builtins.makam
+++ b/examples/lib/builtins.makam
@@ -81,7 +81,10 @@ removableguard : unit -> A -> prop -> prop.
 
 plus : int -> int -> int -> prop.
 mult : int -> int -> int -> prop.
-       (* integer operations. these are bidirectional, so work like minus and div as well. *)
+div : int -> int -> int -> int -> prop.
+       (* integer operations. plus is bidirectional, so works like minus as well. 
+        * mult and div must be used with the first two arguments instantiated
+        *)
 
 lessthan : int -> int -> bool -> prop.
 

--- a/js/index.html
+++ b/js/index.html
@@ -10,7 +10,7 @@
 
       var worker = new Worker('makam.js');
       var terminal = null;
-      const version = "0.7.20";
+      const version = "0.7.21";
      
       $(function() {
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "makam",
-  "version": "0.7.20",
+  "version": "0.7.21",
   "description": "The Makam metalanguage -- a tool for rapid language prototyping",
   "main": "lib/index.js",
   "scripts": {

--- a/opam/opam
+++ b/opam/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "makam"
-version: "0.7.20"
+version: "0.7.21"
 maintainer: "Antonis Stampoulis <antonis.stampoulis@gmail.com>"
 authors: [ "Antonis Stampoulis <antonis.stampoulis@gmail.com>" ]
 license: "GPL-3"

--- a/stdlib/tests.makam
+++ b/stdlib/tests.makam
@@ -241,6 +241,8 @@ let_in : term -> (term -> term) -> term.
 
 (* ------------------- string *)
 
+string : testsuite. %testsuite string.
+
 >> string.concat [ "foo", "bar" ] X ?
 >> Yes:
 >> X := "foobar".
@@ -285,6 +287,48 @@ let_in : term -> (term -> term) -> term.
 >> ((pfun x => eqv `hello ${x}!` `hello world!`) X) ?
 >> Yes:
 >> X := "world".
+
+(* ------------------- int *)
+
+int : testsuite. %testsuite int.
+
+>> mult 2 3 6 ?
+>> Yes.
+
+>> mult 2 3 R ?
+>> Yes:
+>> R := 6.
+
+>> mult 2 R 6 ?
+>> Impossible.
+
+>> mult R 3 6 ?
+>> Impossible.
+
+
+>> div 6 3 Q R ?
+>> Yes:
+>> Q := 2,
+>> R := 0.
+
+>> div 8 3 2 2 ?
+>> Yes.
+
+>> div 6 R 2 0 ?
+>> Impossible.
+
+>> div R 3 2 0 ?
+>> Impossible.
+
+>> div 6 0 Q R ?
+>> Impossible.
+
+>> (plus 4 _B 0, div 25 _B _Q R, plus 6 _Q 0)?
+>> Yes:
+>> R := 1.
+
+>> div 0 0 Q R ?
+>> Impossible.
 
 (* ------------------- concrete reify *)
 

--- a/termlang/termlangext.ml
+++ b/termlang/termlangext.ml
@@ -154,31 +154,41 @@ new_builtin_predicate_from_functions "plus" ( _tInt **> _tInt **> _tInt **> _tPr
     convertfunc (fun a b -> Big_int.add a b) ]
 end;;
 
-new_builtin_predicate_from_functions "mult" ( _tInt **> _tInt **> _tInt **> _tProp ) begin
+
+new_builtin_predicate "mult" ( _tInt **> _tInt **> _tInt **> _tProp ) begin
+  
   let open RunCtx.Monad in
-  let convertfunc f [ i1 ; i2 ] =
-    perform
-      i1' <-- _PtoInt i1 ;
-      i2' <-- _PtoInt i2 ;
-      let res = try Some (f i1' i2') with _ -> None in
-      match res with
-          Some i -> return (_PofInt i ~loc:i1.loc)
-        | None -> mzero
-  in
-  let exact_division x y =
-    let (q, r) = Big_int.quomod_big_int x y in
-    if Big_int.eq_big_int r Big_int.zero_big_int 
-      then q 
-      else failwith "Division had non-zero remainder"
-  in
-  [ (* Meta, Const, Const *)
-    convertfunc (fun b res -> exact_division res b);
+  let isMeta t = match t.term with `LamMany( _, { term = `Meta(_) } ) -> true | _ -> false in
+  (fun _ -> fun [ i1; i2; res ] -> perform
+    i1' <-- chasePattcanon [] i1 ;
+    i2' <-- chasePattcanon [] i2 ;
+    res' <-- chasePattcanon [] res ;
+    if isMeta i1' || isMeta i2' then mzero
+    else (perform
+            i1'' <-- _PtoInt i1' ;
+            i2'' <-- _PtoInt i2' ;
+            pattcanonUnifyFull res' (_PofInt (Big_int.mul i1'' i2'') ~loc:res.loc)))
 
-    (* Const, Meta, Const *)
-    convertfunc (fun a res -> exact_division res a);
+end;;
 
-    (* Const, Const, Meta *)
-    convertfunc (fun a b -> Big_int.mul a b) ]
+new_builtin_predicate "div" ( _tInt **> _tInt **> _tInt **> _tInt **> _tProp ) begin
+  
+  let open RunCtx.Monad in
+  let isMeta t = match t.term with `LamMany( _, { term = `Meta(_) } ) -> true | _ -> false in
+  (fun _ -> fun [ i1; i2; quo; rem ] -> perform
+    i1' <-- chasePattcanon [] i1 ;
+    i2' <-- chasePattcanon [] i2 ;
+    quo' <-- chasePattcanon [] quo ;
+    rem' <-- chasePattcanon [] rem ;
+    if isMeta i1' || isMeta i2' then mzero
+    else (perform
+            i1'' <-- _PtoInt i1' ;
+            i2'' <-- _PtoInt i2' ;
+            try (perform let (q'', r'') = Big_int.quomod_big_int i1'' i2'' in
+            pattcanonUnifyFull quo' (_PofInt q'' ~loc:quo.loc) ;
+            pattcanonUnifyFull rem' (_PofInt r'' ~loc:rem.loc))
+              with _ -> mzero))
+
 end;;
 
 new_builtin_predicate "lessthan" ( _tInt **> _tInt **> _tBool **> _tProp ) begin

--- a/termlang/termlangext.ml
+++ b/termlang/termlangext.ml
@@ -165,11 +165,17 @@ new_builtin_predicate_from_functions "mult" ( _tInt **> _tInt **> _tInt **> _tPr
           Some i -> return (_PofInt i ~loc:i1.loc)
         | None -> mzero
   in
+  let exact_division x y =
+    let (q, r) = Big_int.quomod_big_int x y in
+    if Big_int.eq_big_int r Big_int.zero_big_int 
+      then q 
+      else failwith "Division had non-zero remainder"
+  in
   [ (* Meta, Const, Const *)
-    convertfunc (fun b res -> Big_int.div res b);
+    convertfunc (fun b res -> exact_division res b);
 
     (* Const, Meta, Const *)
-    convertfunc (fun a res -> Big_int.div res a);
+    convertfunc (fun a res -> exact_division res a);
 
     (* Const, Const, Meta *)
     convertfunc (fun a b -> Big_int.mul a b) ]

--- a/toploop/version.ml
+++ b/toploop/version.ml
@@ -1,2 +1,2 @@
-let version = "0.7.20" ;;
-let source_hash = "607a0d845d5a1589c492897145519d6ac2ce5ec1";;
+let version = "0.7.21" ;;
+let source_hash = "b0281bbb35e2971e1f69aaf4b88425f4f6040afa";;

--- a/webui/package.json
+++ b/webui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "makam-webui",
-  "version": "0.7.20",
+  "version": "0.7.21",
   "description": "CodeMirror-based WebUI for Makam",
   "main": "makam-webui-bundle.js",
   "scripts": {


### PR DESCRIPTION
The `mult` primitive was doing integer division when either the first or second argument was uninstantiated.

This gave the following funky results:

```
# mult 3 R 1 ?
Yes:
R := 0.

# mult 3 0 1 ?
Impossible.

# (mult 3 R 1, mult 3 R 1) ?
Impossible.
```
> The last one by @curiousleo

This solution calculates the quotient and the remainder, and it fails if the remainder is not zero.

_**Disclaimer:** This is the first time I write ocaml, there may be a better/more idiomatic way to do it_