### PR TITLE
Make the bash path NixOS compatible

### DIFF
--- a/makam
+++ b/makam
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 


### PR DESCRIPTION
On NixOS (and maybe some other distros) `bash` is not on `/bin/bash`, this means the script doesn't work.

Using this indirection fixes the problem.