### PR TITLE
Implement eqv using structural

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -1,6 +1,6 @@
 OASISFormat: 0.4
 Name:        makam
-Version:     0.7.26
+Version:     0.7.27
 Synopsis:    The Makam Metalanguage -- a tool for rapid language prototyping
 Authors:     Antonis Stampoulis <antonis.stampoulis@gmail.com>
 Homepage:    http://astampoulis.github.io/

--- a/js/index.html
+++ b/js/index.html
@@ -10,7 +10,7 @@
 
       var worker = new Worker('makam.js');
       var terminal = null;
-      const version = "0.7.26";
+      const version = "0.7.27";
      
       $(function() {
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "makam",
-  "version": "0.7.26",
+  "version": "0.7.27",
   "description": "The Makam metalanguage -- a tool for rapid language prototyping",
   "main": "lib/index.js",
   "scripts": {

--- a/opam/files/makam.install
+++ b/opam/files/makam.install
@@ -26,6 +26,7 @@ share: [
   "stdlib/init.makam" {"stdlib/init.makam"}
   "stdlib/iso.makam" {"stdlib/iso.makam"}
   "stdlib/list.makam" {"stdlib/list.makam"}
+  "stdlib/listcomplex.makam" {"stdlib/listcomplex.makam"}
   "stdlib/logging.makam" {"stdlib/logging.makam"}
   "stdlib/map.makam" {"stdlib/map.makam"}
   "stdlib/morerefl.makam" {"stdlib/morerefl.makam"}

--- a/opam/opam
+++ b/opam/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "makam"
-version: "0.7.26"
+version: "0.7.27"
 maintainer: "Antonis Stampoulis <antonis.stampoulis@gmail.com>"
 authors: [ "Antonis Stampoulis <antonis.stampoulis@gmail.com>" ]
 license: "GPL-3"

--- a/stdlib/eqv.makam
+++ b/stdlib/eqv.makam
@@ -6,4 +6,5 @@ eqv : [A]A -> A -> prop.
 
 (* the refl rule can be disabled on a per-type basis *)
 without_eqv_refl : [A]A -> prop.
-eqv (X : A) X when not(without_eqv_refl (Z : A)).
+eqv (X : A) Y when not(without_eqv_refl (Z : A)) :-
+    (structural @(eqv) X Y).

--- a/stdlib/generic.makam
+++ b/stdlib/generic.makam
@@ -42,15 +42,20 @@ structural Rec (X : A -> B) (Y: A -> B) <-
   (x:A -> forall.apply Rec (X x) (Y x)).
 
 (* the essence: forward and backward destructuring *)
-structural Rec X Y when refl.isbaseterm X <-
+structural Rec X Y when not(refl.isunif X), refl.isunif Y, refl.isbaseterm X <-
   refl.headargs X Hd Args,
   map (dyn.call Rec) Args Args',
   refl.headargs Y Hd Args'.
 
-structural Rec X Y when refl.isunif X, refl.isbaseterm Y <-
+structural Rec X Y when refl.isunif X, not(refl.isunif Y), refl.isbaseterm Y <-
   refl.headargs Y Hd Args',
   map (dyn.call Rec) Args Args',
   refl.headargs X Hd Args.
+
+structural Rec X Y when not(refl.isunif X), not(refl.isunif Y), refl.isbaseterm X <-
+  refl.headargs X Hd Args,
+  refl.headargs Y Hd Args',
+  map (dyn.call Rec) Args Args'.
 
 %extend generic.
 fold : [A'] forall A (B -> A -> B -> prop) -> B -> A' -> B -> prop.

--- a/stdlib/init.makam
+++ b/stdlib/init.makam
@@ -1,6 +1,5 @@
 %use basic_predicates.
 %use connectives.
-%use eqv.
 %use clause.
 %use typ.
 
@@ -12,24 +11,29 @@
 %use vector.
 %use hlist.
 %use args.
-%use string.
 %use tuple.
 %use option.
-%use set.
-%use map.
 %use dyn.
 
 %use guard.
 %use demand.
 
-%use logging.
-%use testing.
 %use caching.
 
 %use fluid.
-%use iso.
 
 %use generic.
+%use eqv.
+
+%use listcomplex.
+%use string.
+%use set.
+%use map.
+
+%use logging.
+%use testing.
+
+%use iso.
 
 %use morerefl.
 %use reify.

--- a/stdlib/list.makam
+++ b/stdlib/list.makam
@@ -97,18 +97,6 @@ filtermap Pred (HD :: TL) Res <-
   then (eq Res (HD' :: TL'), filtermap Pred TL TL')
   else (filtermap Pred TL Res).
 
-
-(* Succeeds if a list contains an element *)
-contains : A -> list A -> prop.
-contains X (HD :: TL) <- unless (eqv X HD) (contains X TL).
-
-(* Returns a list with the unique elements *)
-unique : list A -> list A -> prop.
-unique L L' <-
-  foldl (pfun cur elm res => (if contains elm cur then eq res cur else eq res (elm :: cur)) )
-        [] L L'', reverse L'' L'.
-
-
 (* Relates a number of lists to a lists where the corresponding elements are tupled together. Overloaded up to 4 lists. *)
 (* Can be used in the opposite direction to unzip into multiple lists. *)
 zip : list A -> list B -> list C -> list (A * B * C) -> prop.

--- a/stdlib/listcomplex.makam
+++ b/stdlib/listcomplex.makam
@@ -1,0 +1,13 @@
+(* This is separated from the list module since it
+ * generated an recursive implementation with eqv
+ *)
+
+(* Succeeds if a list contains an element *)
+contains : A -> list A -> prop.
+contains X (HD :: TL) <- unless (eqv X HD) (contains X TL).
+
+(* Returns a list with the unique elements *)
+unique : list A -> list A -> prop.
+unique L L' <-
+  foldl (pfun cur elm res => (if contains elm cur then eq res cur else eq res (elm :: cur)) )
+        [] L L'', reverse L'' L'.

--- a/stdlib/tests.makam
+++ b/stdlib/tests.makam
@@ -190,7 +190,7 @@ testcase reify :-
 testcase reify :- unif_alpha_eqv (X: string) (Y: string).
 testcase reify :- not(unif_alpha_eqv (dyn (X: string)) (dyn (Y: int))).
 testcase reify :- unif_alpha_eqv (lam X) (lam Y).
-testcase reify :- not(unif_alpha_eqv (app X Y) (app W W)).
+testcase reify :- unif_alpha_eqv (app X Y) (app W W).
 testcase reify :- not({prop|(x:term -> ([With_x] unif_alpha_eqv (With_x: term) (Without_x: term))) |}).
 
 

--- a/toploop/version.ml
+++ b/toploop/version.ml
@@ -1,2 +1,2 @@
-let version = "0.7.26" ;;
+let version = "0.7.27" ;;
 let source_hash = "2d68d1f956d1c20772748a53a6ee6c538ec58c34";;

--- a/webui/package.json
+++ b/webui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "makam-webui",
-  "version": "0.7.26",
+  "version": "0.7.27",
   "description": "CodeMirror-based WebUI for Makam",
   "main": "makam-webui-bundle.js",
   "scripts": {


### PR DESCRIPTION
A few changes to implement #64 
 * Actually change the implementation of `eqv`
 * Divide the `stdlib/list` file into two, to avoid the infinite dependency
 * Change the order of some imports on `stdlib/init`
 * One test started failing on `stdib/tests` because of the change to `eqv`, fixed the test, but this may be a mistake (please check @astampoulis )
 * Changed the implementation of `structural`, now it differentiates between all 4 cases of "which of [X, Y] is a unification variable". Without this, `structural` with `eqv` cause an infinite loop with `set`. (We can discuss this further if you think there's no need or it's better not to).
 * Bumped version to 0.7.27

Closes #64 and #71 (not on purpose)