### PR TITLE
Only check once if the tests should be run verbose

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -1,6 +1,6 @@
 OASISFormat: 0.4
 Name:        makam
-Version:     0.7.26
+Version:     0.7.27
 Synopsis:    The Makam Metalanguage -- a tool for rapid language prototyping
 Authors:     Antonis Stampoulis <antonis.stampoulis@gmail.com>
 Homepage:    http://astampoulis.github.io/

--- a/js/index.html
+++ b/js/index.html
@@ -10,7 +10,7 @@
 
       var worker = new Worker('makam.js');
       var terminal = null;
-      const version = "0.7.26";
+      const version = "0.7.27";
      
       $(function() {
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "makam",
-  "version": "0.7.26",
+  "version": "0.7.27",
   "description": "The Makam metalanguage -- a tool for rapid language prototyping",
   "main": "lib/index.js",
   "scripts": {

--- a/opam/opam
+++ b/opam/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "makam"
-version: "0.7.26"
+version: "0.7.27"
 maintainer: "Antonis Stampoulis <antonis.stampoulis@gmail.com>"
 authors: [ "Antonis Stampoulis <antonis.stampoulis@gmail.com>" ]
 license: "GPL-3"

--- a/stdlib/testing.makam
+++ b/stdlib/testing.makam
@@ -34,7 +34,7 @@ run_test Suites Successes Failures (testcase X) [] <- handle_result Successes Fa
 run_test Suites Successes Failures (testcase X) (TestCase :: TL) <-
   if (once(find (fun suite => clause.applies (testcase suite) TestCase) Suites _))
   then (
-    if (verbose_run_tests) then (
+    if (once(verbose_run_tests)) then (
       tostring TestCase TestCaseS,
       log_info_do TestCase "Testcase" `${TestCaseS}`
     ) else success,

--- a/toploop/version.ml
+++ b/toploop/version.ml
@@ -1,2 +1,2 @@
-let version = "0.7.26" ;;
+let version = "0.7.27" ;;
 let source_hash = "2d68d1f956d1c20772748a53a6ee6c538ec58c34";;

--- a/webui/package.json
+++ b/webui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "makam-webui",
-  "version": "0.7.26",
+  "version": "0.7.27",
   "description": "CodeMirror-based WebUI for Makam",
   "main": "makam-webui-bundle.js",
   "scripts": {


### PR DESCRIPTION
When multiple definitions of `verbose_run_tests` are present, under tests failures the testing library behaves weirdly.

The example below is a toy example, but this could easily happen if we are testing two different files: `makam simpletests.makam complextests.makam --run-tests` and both have `verbose_run_tests.` on them.

```
testy : testsuite.

verbose_run_tests.
verbose_run_tests.

testcase testy :- failure.
```