### PR TITLE
map for option

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -1,6 +1,6 @@
 OASISFormat: 0.4
 Name:        makam
-Version:     0.7.27
+Version:     0.7.28
 Synopsis:    The Makam Metalanguage -- a tool for rapid language prototyping
 Authors:     Antonis Stampoulis <antonis.stampoulis@gmail.com>
 Homepage:    http://astampoulis.github.io/

--- a/js/index.html
+++ b/js/index.html
@@ -10,7 +10,7 @@
 
       var worker = new Worker('makam.js');
       var terminal = null;
-      const version = "0.7.27";
+      const version = "0.7.28";
      
       $(function() {
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "makam",
-  "version": "0.7.27",
+  "version": "0.7.28",
   "description": "The Makam metalanguage -- a tool for rapid language prototyping",
   "main": "lib/index.js",
   "scripts": {

--- a/opam/opam
+++ b/opam/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "makam"
-version: "0.7.27"
+version: "0.7.28"
 maintainer: "Antonis Stampoulis <antonis.stampoulis@gmail.com>"
 authors: [ "Antonis Stampoulis <antonis.stampoulis@gmail.com>" ]
 license: "GPL-3"

--- a/stdlib/option.makam
+++ b/stdlib/option.makam
@@ -1,3 +1,26 @@
 option : type -> type.
 none : option A.
 some : A -> option A.
+
+(* Map a predicate over (a number of) options.
+
+   We overload the map_op predicate to work on up to 4 options,
+   but define the most commonly used version last -- the one on 2 lists.
+   This way if no typing constraints are present, the common version will be picked
+   by default. *)
+
+map_op : (A -> prop) -> option A -> prop.
+map_op P none.
+map_op P (some A) <- P A.
+
+map_op : (A -> B -> C -> prop) -> option A -> option B -> option C -> prop.
+map_op P none none none.
+map_op P (some A1) (some A2) (some A3) <- P A1 A2 A3.
+
+map_op : (A -> B -> C -> D -> prop) -> option A -> option B -> option C -> option D -> prop.
+map_op P none none none none.
+map_op P (some A1) (some A2) (some A3) (some A4) <- P A1 A2 A3 A4.
+
+map_op : (A -> B -> prop) -> option A -> option B -> prop.
+map_op P none none.
+map_op P (some A1) (some A2) <- P A1 A2.

--- a/stdlib/option.makam
+++ b/stdlib/option.makam
@@ -2,25 +2,29 @@ option : type -> type.
 none : option A.
 some : A -> option A.
 
+%extend option.
+
 (* Map a predicate over (a number of) options.
 
-   We overload the map_op predicate to work on up to 4 options,
+   We overload the map predicate to work on up to 4 options,
    but define the most commonly used version last -- the one on 2 lists.
    This way if no typing constraints are present, the common version will be picked
    by default. *)
 
-map_op : (A -> prop) -> option A -> prop.
-map_op P none.
-map_op P (some A) <- P A.
+map : (A -> prop) -> option A -> prop.
+map P none.
+map P (some A) <- P A.
 
-map_op : (A -> B -> C -> prop) -> option A -> option B -> option C -> prop.
-map_op P none none none.
-map_op P (some A1) (some A2) (some A3) <- P A1 A2 A3.
+map : (A -> B -> C -> prop) -> option A -> option B -> option C -> prop.
+map P none none none.
+map P (some A1) (some A2) (some A3) <- P A1 A2 A3.
 
-map_op : (A -> B -> C -> D -> prop) -> option A -> option B -> option C -> option D -> prop.
-map_op P none none none none.
-map_op P (some A1) (some A2) (some A3) (some A4) <- P A1 A2 A3 A4.
+map : (A -> B -> C -> D -> prop) -> option A -> option B -> option C -> option D -> prop.
+map P none none none none.
+map P (some A1) (some A2) (some A3) (some A4) <- P A1 A2 A3 A4.
 
-map_op : (A -> B -> prop) -> option A -> option B -> prop.
-map_op P none none.
-map_op P (some A1) (some A2) <- P A1 A2.
+map : (A -> B -> prop) -> option A -> option B -> prop.
+map P none none.
+map P (some A1) (some A2) <- P A1 A2.
+
+%end.

--- a/stdlib/tests.makam
+++ b/stdlib/tests.makam
@@ -515,26 +515,26 @@ foo X Y (W, "y") when eq_nounif Y 1.
 
 (* -------------------- option (map) *)
 
->> map_op (eq 2) none ?
+>> option.map (eq 2) none ?
 >> Yes.
 
->> map_op (eq 2) (some 1) ?
+>> option.map (eq 2) (some 1) ?
 >> Impossible.
 
->> map_op (eq X) (some 2) ?
+>> option.map (eq X) (some 2) ?
 >> Yes:
 >> X := 2.
 
->> map_op plus (some 1) (some 2) X ?
+>> option.map plus (some 1) (some 2) X ?
 >> Yes:
 >> X := some 3.
 
->> map_op plus none X Y ?
+>> option.map plus none X Y ?
 >> Yes:
 >> X := none,
 >> Y := none.
 
->> map_op plus none (some _) none ?
+>> option.map plus none (some _) none ?
 >> Impossible.
 
 %end.

--- a/stdlib/tests.makam
+++ b/stdlib/tests.makam
@@ -513,4 +513,28 @@ foo X Y (W, "y") when eq_nounif Y 1.
 >> (guardmany [X] (success), failure) ?
 >> Impossible.
 
+(* -------------------- option (map) *)
+
+>> map_op (eq 2) none ?
+>> Yes.
+
+>> map_op (eq 2) (some 1) ?
+>> Impossible.
+
+>> map_op (eq X) (some 2) ?
+>> Yes:
+>> X := 2.
+
+>> map_op plus (some 1) (some 2) X ?
+>> Yes:
+>> X := some 3.
+
+>> map_op plus none X Y ?
+>> Yes:
+>> X := none,
+>> Y := none.
+
+>> map_op plus none (some _) none ?
+>> Impossible.
+
 %end.

--- a/toploop/version.ml
+++ b/toploop/version.ml
@@ -1,2 +1,2 @@
-let version = "0.7.27" ;;
+let version = "0.7.28" ;;
 let source_hash = "2d68d1f956d1c20772748a53a6ee6c538ec58c34";;

--- a/webui/package.json
+++ b/webui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "makam-webui",
-  "version": "0.7.27",
+  "version": "0.7.28",
   "description": "CodeMirror-based WebUI for Makam",
   "main": "makam-webui-bundle.js",
   "scripts": {


### PR DESCRIPTION
I found myself doing this kind of mapping over `option`s, I think this is useful and very simple.

I tried naming it `map`, but got the following error:

```
!! Error in file ./examples/tinyml/eval.makam, line 51, characters 13-15:
   Variable cons with type expr -> A -> option expr does not exist.
```

And the blamed line is:

```
  map eval [E1, E2] [V1, V2],
```

This might be a problem with the makam typechecker, or maybe it's expected behaviour (I'm really not sure).