### PR TITLE
add hexademical literals for ints

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -1,6 +1,6 @@
 OASISFormat: 0.4
 Name:        makam
-Version:     0.7.32
+Version:     0.7.33
 Synopsis:    The Makam Metalanguage -- a tool for rapid language prototyping
 Authors:     Antonis Stampoulis <antonis.stampoulis@gmail.com>
 Homepage:    http://astampoulis.github.io/

--- a/grammars/makamGrammar.peg
+++ b/grammars/makamGrammar.peg
@@ -591,7 +591,8 @@ letterchar -> &&( .
               a:. << a >>
 latin1letter -> &latin1char c:letterchar << c >>
 digitchar -> a:[0123456789]              << a >>
-num       -> is:repplus(digitchar)       << is |> UString.implode |> UString.to_string |> Big_int.of_string >>
+num       -> "0x" is:repplus(hexdigitchar) << ("0x" ^ (is |> UString.implode |> UString.to_string)) |> Big_int.of_string >>
+           / is:repplus(digitchar)         << is |> UString.implode |> UString.to_string |> Big_int.of_string >>;
 eof -> !. ;
 
 (* whitespace *)

--- a/js/index.html
+++ b/js/index.html
@@ -10,7 +10,7 @@
 
       var worker = new Worker('makam.js');
       var terminal = null;
-      const version = "0.7.32";
+      const version = "0.7.33";
      
       $(function() {
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "makam",
-  "version": "0.7.32",
+  "version": "0.7.33",
   "description": "The Makam metalanguage -- a tool for rapid language prototyping",
   "main": "lib/index.js",
   "scripts": {

--- a/opam/opam
+++ b/opam/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "makam"
-version: "0.7.32"
+version: "0.7.33"
 maintainer: "Antonis Stampoulis <antonis.stampoulis@gmail.com>"
 authors: [ "Antonis Stampoulis <antonis.stampoulis@gmail.com>" ]
 license: "GPL-3"

--- a/tests/core_tests.makam
+++ b/tests/core_tests.makam
@@ -99,3 +99,8 @@ testcase makam_core :- makam_core_tests.a X, (eq X 5; eq X 4).
 testcase makam_core :- makam_core_tests.a X, (if (makam_core_tests.b 3) then failure else eq X 4).
 testcase makam_core :- makam_core_tests.a X, eq X 101.
 testcase makam_core :- makam_core_tests.a 201.
+
+(* Tests for hex parsing *)
+
+testcase makam_core :- eq 0xada 2778.
+

--- a/toploop/version.ml
+++ b/toploop/version.ml
@@ -1,2 +1,2 @@
-let version = "0.7.32" ;;
-let source_hash = "5910e59236d920b84dd2d4570d74c9c4256d17a0";;
+let version = "0.7.33" ;;
+let source_hash = "4254a434b58a53b81a49e4afb39f4843a1980a5b";;

--- a/webui/package.json
+++ b/webui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "makam-webui",
-  "version": "0.7.32",
+  "version": "0.7.33",
   "description": "CodeMirror-based WebUI for Makam",
   "main": "makam-webui-bundle.js",
   "scripts": {


### PR DESCRIPTION
Fixes #87 .

@suhr Note that this only solves the parsing issue you ran into. Integers are still printed as decimals, even if they were initially parsed as hex literals. Do you also need printing as hex literals for your purposes? That will be a little bit a more involved.