### PR TITLE
add experimental functional syntax

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ TESTS= \
 tests/core_tests \
 stdlib/tests \
 stdlib/concrete_bind.tests \
+stdlib/functional.tests \
 stdlib/parsing/tests \
 stdlib/parsing/tests_opt \
 stdlib/parsing/peg_grammar \

--- a/_oasis
+++ b/_oasis
@@ -1,6 +1,6 @@
 OASISFormat: 0.4
 Name:        makam
-Version:     0.7.34
+Version:     0.7.35
 Synopsis:    The Makam Metalanguage -- a tool for rapid language prototyping
 Authors:     Antonis Stampoulis <antonis.stampoulis@gmail.com>
 Homepage:    http://astampoulis.github.io/

--- a/grammars/makamGrammar.peg
+++ b/grammars/makamGrammar.peg
@@ -185,6 +185,8 @@ baseexpr -> id:ltoken(qualident)   << autospan_un mkVar id >>
           / id:ltoken( ("#" s:identany << s >>) ) << autospan_un mkCapturingVar id >>
           / token("@") e:baseexpr
             << mkTm "mkforall" [ e ] >>
+          / token("!") e:baseexpr
+            << mkTm "lift" [ e ] >>
           / s:loced( ( token(["]) str:rep(strchar) ["] << str |> String.concat "" >> ) )
             << autospan_un mkString s >>
 

--- a/grammars/makamGrammar.peg
+++ b/grammars/makamGrammar.peg
@@ -591,8 +591,10 @@ letterchar -> &&( .
               a:. << a >>
 latin1letter -> &latin1char c:letterchar << c >>
 digitchar -> a:[0123456789]              << a >>
+sign      -> x:[-] << [x] >>
+           / epsilon << [] >>
 num       -> "0x" is:repplus(hexdigitchar) << ("0x" ^ (is |> UString.implode |> UString.to_string)) |> Big_int.of_string >>
-           / is:repplus(digitchar)         << is |> UString.implode |> UString.to_string |> Big_int.of_string >>;
+           / sign:sign is:repplus(digitchar)  << (List.append sign is) |> UString.implode |> UString.to_string |> Big_int.of_string >>;
 eof -> !. ;
 
 (* whitespace *)

--- a/js/index.html
+++ b/js/index.html
@@ -10,7 +10,7 @@
 
       var worker = new Worker('makam.js');
       var terminal = null;
-      const version = "0.7.34";
+      const version = "0.7.35";
      
       $(function() {
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "makam",
-  "version": "0.7.34",
+  "version": "0.7.35",
   "description": "The Makam metalanguage -- a tool for rapid language prototyping",
   "main": "lib/index.js",
   "scripts": {

--- a/opam/files/makam.install
+++ b/opam/files/makam.install
@@ -24,6 +24,7 @@ share: [
   "stdlib/guard.makam" {"stdlib/guard.makam"}
   "stdlib/hlist.makam" {"stdlib/hlist.makam"}
   "stdlib/init.makam" {"stdlib/init.makam"}
+  "stdlib/int.makam" {"stdlib/int.makam"}
   "stdlib/iso.makam" {"stdlib/iso.makam"}
   "stdlib/list.makam" {"stdlib/list.makam"}
   "stdlib/logging.makam" {"stdlib/logging.makam"}

--- a/opam/files/makam.install
+++ b/opam/files/makam.install
@@ -19,6 +19,7 @@ share: [
   "stdlib/eqv.makam" {"stdlib/eqv.makam"}
   "stdlib/fluid.makam" {"stdlib/fluid.makam"}
   "stdlib/forall.makam" {"stdlib/forall.makam"}
+  "stdlib/functional.makam" {"stdlib/functional.makam"}
   "stdlib/generic.makam" {"stdlib/generic.makam"}
   "stdlib/guard.makam" {"stdlib/guard.makam"}
   "stdlib/hlist.makam" {"stdlib/hlist.makam"}

--- a/opam/opam
+++ b/opam/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "makam"
-version: "0.7.34"
+version: "0.7.35"
 maintainer: "Antonis Stampoulis <antonis.stampoulis@gmail.com>"
 authors: [ "Antonis Stampoulis <antonis.stampoulis@gmail.com>" ]
 license: "GPL-3"

--- a/stdlib/functional.makam
+++ b/stdlib/functional.makam
@@ -1,0 +1,89 @@
+(*
+
+This is an experiment at functional syntax for Makam.
+
+This is inspired by the Idris !-notation:
+  http://docs.idris-lang.org/en/latest/tutorial/interfaces.html#notation
+and the Ciao functional syntax:
+  http://ciao-lang.org/ciao/build/doc/ciao.html/fsyntax_doc.html
+
+It introduces a "magic" operator `lift` that allows us to turn a one-argument
+logic predicate of type `A -> prop` into a value of type A. The syntactic sugar
+`!P` stands for `lift P`.
+
+The `functional.do` predicate can be used to execute code containing instances
+of `lift`.
+
+Usage example:
+
+functional.do !(plus 10 !(plus 20 30)) X ?
+
+*)
+
+lift : (A -> prop) -> A.
+
+%extend functional.
+
+a_normal : type -> type.
+
+return : A -> a_normal A.
+bind : (A -> prop) -> (A -> a_normal B) -> a_normal B.
+
+(* converts a-normalized code into a logical predicate *)
+convert_a_normal : a_normal A -> (A -> prop) -> prop.
+
+convert_a_normal (return X) (pfun result => eq result X).
+convert_a_normal (bind (P_A: Type_A -> prop) (K: Type_A -> a_normal Type_B))
+        (pfun result => [ValueA] (P_A ValueA, P_K ValueA result)) :-
+   (a:Type_A -> convert_a_normal (K a) (P_K a)).
+
+
+(* finds the innermost, leftmost instance of a `lift` inside a term,
+   and returns the `lift` instance and the hole containing it *)
+find_lift : B -> (A -> prop) -> (A -> B) -> prop.
+
+find_lift_aux, find_lift_rules : [A] dyn -> dyn -> A -> A -> prop.
+
+find_lift_rules DynReplacement Lift
+                (lift X) Context
+    when refl.isunif Lift, not(find_lift X _ _) :-
+  dyn.eq DynReplacement (dyn Context),
+  dyn.eq Lift (dyn (lift X)).
+
+find_lift_aux Replacement Lift Context Context' :-
+  demand.case_otherwise
+    (find_lift_rules Replacement Lift Context Context')
+    (structural @(find_lift_aux Replacement Lift) Context Context').
+
+find_lift Input Lift Hole :-
+  (x:A ->
+     ([Lift' Hole']
+     find_lift_aux (dyn x) LiftResult Input Hole',
+     not(refl.isunif LiftResult),
+     dyn.eq LiftResult (dyn (lift Lift)),
+     dyn.eq Hole' (Hole x))).
+
+(* converts functional code containing lifts into a-normalized code.
+   The type of the first argument is imprecise here: the code is not
+   yet in a-normal form, since it potentially contains nested instances
+   of `lift`. *)
+to_a_normal : [A] a_normal A -> a_normal A -> prop.
+to_a_normal Input Input when not(find_lift Input _ _).
+to_a_normal Input (bind First Rest) :-
+  find_lift Input First Hole,
+  (x:A -> to_a_normal (Hole x) (Rest x)).
+
+(* converts code containing instances of `lift` into a one-argument predicate *)
+hoist_lifts : A -> (A -> prop) -> prop.
+hoist_lifts FunctionalCode LogicCode :-
+  to_a_normal (return FunctionalCode) ANormalCode,
+  convert_a_normal ANormalCode LogicCode.
+
+(* executes code containing instances of `lift` *)
+do : A -> A -> prop.
+
+do FunctionalCode Result :-
+  hoist_lifts FunctionalCode LogicCode,
+  LogicCode Result.
+
+%end.

--- a/stdlib/functional.makam
+++ b/stdlib/functional.makam
@@ -46,9 +46,12 @@ find_lift_aux, find_lift_rules : [A] dyn -> dyn -> A -> A -> prop.
 
 find_lift_rules DynReplacement Lift
                 (lift X) Context
-    when refl.isunif Lift, not(find_lift X _ _) :-
-  dyn.eq DynReplacement (dyn Context),
-  dyn.eq Lift (dyn (lift X)).
+    when refl.isunif Lift :-
+  find_lift_aux DynReplacement Lift X Context',
+  if (refl.isunif Lift)
+  then (dyn.eq (dyn Context) DynReplacement,
+        dyn.eq Lift (dyn (lift X)))
+  else (dyn.eq Context (lift Context')).
 
 find_lift_aux Replacement Lift Context Context' :-
   demand.case_otherwise

--- a/stdlib/functional.tests.makam
+++ b/stdlib/functional.tests.makam
@@ -1,0 +1,45 @@
+functional_tests : testsuite. %testsuite functional_tests.
+
+%use functional.
+
+%open functional.
+
+>> find_lift (lift (eq "foo")) X Y ?
+>> Yes:
+>> X := eq "foo",
+>> Y := (fun x => x).
+
+>> find_lift (return (lift (eq "foo"))) X Y ?
+>> Yes:
+>> X := eq "foo",
+>> Y := (fun x => return x).
+
+>> find_lift (return !(plus 5 !(plus 5 2))) X Y ?
+>> Yes:
+>> X := plus 5 2,
+>> Y := (fun x => return !(plus 5 x)).
+
+
+>> to_a_normal (return (lift (eq "foo"))) X ?
+>> Yes:
+>> X := bind (eq "foo") (fun x => return x).
+
+>> to_a_normal (return !(plus 5 !(plus 5 2))) X ?
+>> Yes:
+>> X := bind (plus 5 2) (fun a => bind (plus 5 a) (fun b => return b)).
+
+>> to_a_normal (return !(plus !(minus 5 2) !(plus 5 2))) X ?
+>> Yes:
+>> X := bind (minus 5 2) (fun a => bind (plus 5 2) (fun b => bind (plus a b) (fun c => return c))).
+
+>> functional.do !(plus 5 2) X ?
+>> Yes:
+>> X := 7.
+
+>> functional.do !(plus !(plus 5 2) !(plus 5 3)) X ?
+>> Yes:
+>> X := 15.
+
+>> functional.do !(plus !(minus 5 5) !(plus 5 3)) X ?
+>> Yes:
+>> X := 8.

--- a/stdlib/init.makam
+++ b/stdlib/init.makam
@@ -6,6 +6,7 @@
 
 %use forall.
 
+%use int.
 %use list.
 %use vector.
 %use hlist.

--- a/stdlib/int.makam
+++ b/stdlib/int.makam
@@ -1,0 +1,3 @@
+minus : int -> int -> int -> prop.
+minus A B Result :-
+  plus B Result A.

--- a/stdlib/tests.makam
+++ b/stdlib/tests.makam
@@ -9,6 +9,23 @@ testcase builtins :- guard X success, refl.open_constraints X.
 testcase builtins :- guard X success, not(refl.open_constraints Y).
 testcase builtins :- guard X success, eq X "foo", not(refl.open_constraints X).
 
+(* ------------------- int *)
+
+ints : testsuite.
+
+testcase ints :- plus 5 2 X, eq X 7.
+testcase ints :- plus X 5 7, eq X 2.
+testcase ints :- plus X 5 0, eq X -5.
+testcase ints :- minus 5 2 X, eq X 3.
+testcase ints :- minus 0 5 X, eq X -5.
+testcase ints :- mult 5 2 X, eq X 10.
+testcase ints :- mult -1 5 X, eq X -5.
+testcase ints :- mult -5 -5 X, eq X 25.
+testcase ints :- div 5 2 Quot Rem, eq Quot 2, eq Rem 1.
+testcase ints :- div 10 2 Quot Rem, eq Quot 5, eq Rem 0.
+testcase ints :- div -10 2 Quot Rem, eq Quot -5, eq Rem 0.
+testcase ints :- div -11 2 Quot Rem, eq Quot -6, eq Rem 1.
+
 (* ------------------- eqv *)
 
 icase : type.

--- a/toploop/version.ml
+++ b/toploop/version.ml
@@ -1,2 +1,2 @@
-let version = "0.7.34" ;;
-let source_hash = "182ba6890bfccb4bcfe88bec602d9f82fe483ece";;
+let version = "0.7.35" ;;
+let source_hash = "f32923b9d33809a247691befb51b0294e77ac1c2";;

--- a/webui/package.json
+++ b/webui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "makam-webui",
-  "version": "0.7.34",
+  "version": "0.7.35",
   "description": "CodeMirror-based WebUI for Makam",
   "main": "makam-webui-bundle.js",
   "scripts": {


### PR DESCRIPTION
This adds support for functional syntax, inspired by the [Idris !-notation](http://docs.idris-lang.org/en/latest/tutorial/interfaces.html#notation) and also the [Ciao functional syntax](http://ciao-lang.org/ciao/build/doc/ciao.html/fsyntax_doc.html) as pointed out by @suhr. Prompted by a discussion in #83.

It is quite bare-bones for now, allowing us to do things like `functional.do !(plus 5 !(plus 5 10)) X` instead of the more cumbersome `plus 5 10 A, plus 5 A X`. Could be generalized to also include `let!`-notation; to handle some form of monadic code; and to provide some syntax for functional clauses where the lift hoisting happens statically rather than dynamically.

Note that this is experimental so it might change. I have made the module opt-in for now, so you'll have to do `%use functional.` in your files if you want to use this!

Also adds `minus` for ints and some tests for the builtins.