### PR TITLE
fix transformer state capture

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -1,6 +1,6 @@
 OASISFormat: 0.4
 Name:        makam
-Version:     0.7.39
+Version:     0.7.40
 Synopsis:    The Makam Metalanguage -- a tool for rapid language prototyping
 Authors:     Antonis Stampoulis <antonis.stampoulis@gmail.com>
 Homepage:    http://astampoulis.github.io/

--- a/grammars/makamGrammar.peg
+++ b/grammars/makamGrammar.peg
@@ -336,7 +336,7 @@ prologcmd1 ->
                      (Benchmark.cumulative "total queries" (lazy(global_typecheck_silent p.content)))
                    else
                      (let cmd = mkTm "cmd_stage" [ p ] in
-                      let staged = mkTm "handle_toplevel_command" [ cmd ] in
+                      let staged = mkTm !command_handler [ cmd ] in
                       Benchmark.cumulative "total staged commands"
                       (lazy(Termlangrefl.global_staged_command staged.content)))) >>
 
@@ -351,7 +351,7 @@ prologcmd1 ->
                    (lazy(global_typecheck_silent c.content)))
               else
                 (let cmd = mkTm "cmd_newclause" [ c ] in
-                 let staged = mkTm "handle_toplevel_command" [ cmd ] in
+                 let staged = mkTm !command_handler [ cmd ] in
                  Benchmark.cumulative "total staged commands"
                  (lazy(Termlangrefl.global_staged_command staged.content)))
              ) >>
@@ -363,7 +363,7 @@ prologcmd1 ->
                       (lazy(global_typecheck_silent p.content)))
                   else
                    (let cmd = mkTm "cmd_query" [ p ] in
-                    let staged = mkTm "handle_toplevel_command" [ cmd ] in
+                    let staged = mkTm !command_handler [ cmd ] in
                     Benchmark.cumulative "total staged commands"
                     (lazy(Termlangrefl.global_staged_command staged.content)))) >>
            / p:quoteline(hyp) token("?") << fun () -> global_set_last_query (Some p) >>
@@ -377,7 +377,7 @@ prologcmd1 ->
                               (lazy(global_typecheck_silent (t query).content)))
                            else
                             (let cmd = mkTm "cmd_newclause" [ t query ] in
-                             let staged = mkTm "handle_toplevel_command" [ cmd ] in
+                             let staged = mkTm !command_handler [ cmd ] in
                              Benchmark.cumulative "total staged commands"
                              (lazy(Termlangrefl.global_staged_command staged.content))))
                          >>
@@ -437,6 +437,8 @@ directive -> "use" repplus(white) s:token(ident_or_str)
            << fun () -> Printf.printf "Current module: %a\n" (Option.print String.print) (!globalstate).current_module >>
            / "testsuite" repplus(white) s:token(ident)
            << fun () -> global_set_testsuite s >>
+           / "command_handler" repplus(white) s:token(ident)
+           << fun () -> command_handler := s >>
 
           / b:flag("debug") << fun () -> _DEBUG_DEMAND := b >>
           / b:flag("debugfull") << fun () -> _DEBUG := b >>

--- a/js/index.html
+++ b/js/index.html
@@ -10,7 +10,7 @@
 
       var worker = new Worker('makam.js');
       var terminal = null;
-      const version = "0.7.39";
+      const version = "0.7.40";
      
       $(function() {
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "makam",
-  "version": "0.7.39",
+  "version": "0.7.40",
   "description": "The Makam metalanguage -- a tool for rapid language prototyping",
   "main": "lib/index.js",
   "scripts": {

--- a/opam/opam
+++ b/opam/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "makam"
-version: "0.7.39"
+version: "0.7.40"
 maintainer: "Antonis Stampoulis <antonis.stampoulis@gmail.com>"
 authors: [ "Antonis Stampoulis <antonis.stampoulis@gmail.com>" ]
 license: "GPL-3"

--- a/stdlib/morerefl.makam
+++ b/stdlib/morerefl.makam
@@ -64,6 +64,16 @@ isbasehead (F: T) :-
      only in the case where the head is completely unapplied will the types match. *)
   refl.headargs F_Body (F_HD: T) _.
 
+
+(* a typed version of `refl.headargs` *)
+decompose_term : [Full Head] Full -> Head -> args Head Full -> prop.
+decompose_term Term Head Args :-
+  refl.headargs Term Head ArgsDyn,
+  dyn.to_args ArgsDyn Args.
+
+(* the inverse of `decompose_term` *)
+recompose_term : [Full Head] Head -> args Head Full -> Full -> prop.
+recompose_term Head Args Term when not(refl.isunif Head) :-
+  args.applyfull Head Args Term.
+
 %end.
-
-

--- a/stdlib/tests.makam
+++ b/stdlib/tests.makam
@@ -453,6 +453,27 @@ refl : testsuite. %testsuite refl.
 >> refl.isfun (tuple 1 2) ?
 >> Impossible.
 
+(* -------------------- refl.decompose_term and recompose_term *)
+
+>> refl.decompose_term (1, "foo") Head Args ?
+>> Yes:
+>> Head := (tuple: int -> string -> tuple int string),
+>> Args := [1, "foo"].
+
+foo : type.
+
+>> (f:(foo -> foo) -> (x:foo -> refl.decompose_term (f x) (Head f x) (Args f x))) ?
+>> Yes:
+>> Head := fun f => fun x => f,
+>> Args := fun f => fun x => [x].
+
+>> refl.decompose_term X Head Args ?
+>> Impossible.
+
+>> refl.recompose_term tuple [1, "foo"] X ?
+>> Yes:
+>> X := (1, "foo").
+
 (* -------------------- demand.case_otherwise *)
 
 demand : testsuite. %testsuite demand.

--- a/stdlib/transformers/init.makam
+++ b/stdlib/transformers/init.makam
@@ -60,10 +60,7 @@ aux CmdInput CmdOutput :-
 
 %end.
 
-
-(* subtlety: this needs to be the first clause, so that the next rules
-   comprising the user-defined `handle_toplevel_command` can be handled
-   correctly *)
+handle_toplevel_command : cmd -> cmd -> prop.
 
 handle_toplevel_command Cmd Cmd'
   when not(refl.isunif Cmd),
@@ -88,3 +85,5 @@ handle_toplevel_command Cmd Cmd'
        eq Cmd (cmd_many Cmds) :-
   eq Cmd' (cmd_many Cmds'),
   map handle_toplevel_command Cmds Cmds'.
+
+%command_handler handle_toplevel_command.

--- a/termlang/termlangprolog.ml
+++ b/termlang/termlangprolog.ml
@@ -102,6 +102,7 @@ let _BENCHMARK      : bool ref = Benchmark.enabled ;;
 let _LOGGING        : bool ref = ref false ;;
 let _ONLY_TYPECHECK : bool ref = ref false ;;
 let last_query_successful : bool option ref = ref None ;;
+let command_handler : string ref = ref "builtin_handle_toplevel_command" ;;
 let is_interactive : bool ref = ref false ;;
 
 let metaindex     (_, idx, _, _) = idx ;;

--- a/termlang/termlangrefl.ml
+++ b/termlang/termlangrefl.ml
@@ -767,13 +767,12 @@ let doStagedCommand (code : exprU) : unit RunCtx.Monad.m =
 let global_staged_command cmdcode =
 
   let open RunCtx.Monad in
-  globalprolog_do (
-                    let* cmdcode = intermlang cmdcode in
-                    doStagedCommand cmdcode)
+  globalprolog_do (let* cmdcode = intermlang cmdcode in
+                   doStagedCommand cmdcode)
 
 ;;
 
-new_builtin_predicate "handle_toplevel_command" ( _tCmd **> _tCmd **> _tProp)
+new_builtin_predicate "builtin_handle_toplevel_command" ( _tCmd **> _tCmd **> _tProp)
     (let open RunCtx.Monad in
      fun _ -> function [ cmdin ; cmdout ] ->
                 pattcanonUnifyFull cmdin cmdout

--- a/toploop/repl.ml
+++ b/toploop/repl.ml
@@ -65,23 +65,25 @@ let get_full_state () =
   let doit _ x = !x in
   let (a0, a1,
        a2, a3, a4, a5,
-       a6, a7, a8, a9, a10, a11) = "", "", "", "", "", "", "", "", "", "", "", "" in
+       a6, a7, a8, a9, a10, a11, a12) = "", "", "", "", "", "", "", "", "", "", "", "", "" in
   (doit a0 globalstate, doit a1 globalprologstate,
    doit a2 _DEBUG, doit a3 _DEBUG_DEMAND, doit a4 _DEBUG_NAMES, doit a5 _DEBUG_TYPES,
    doit a6 _DEBUG_STAGING, doit a7 _BENCHMARK, doit a8 _LOGGING, doit a9 _ONLY_TYPECHECK,
-   doit a10 last_query_successful, doit a11 UChannel.input_statehash)
+   doit a10 last_query_successful, doit a11 UChannel.input_statehash,
+   doit a12 command_handler)
 ;;
 
 let set_full_state st =
   let doit a x = x := a in
   let (a0, a1,
        a2, a3, a4, a5,
-       a6, a7, a8, a9, a10, a11) = st in
+       a6, a7, a8, a9, a10, a11, a12) = st in
   ignore
   (doit a0 globalstate, doit a1 globalprologstate,
    doit a2 _DEBUG, doit a3 _DEBUG_DEMAND, doit a4 _DEBUG_NAMES, doit a5 _DEBUG_TYPES,
    doit a6 _DEBUG_STAGING, doit a7 _BENCHMARK, doit a8 _LOGGING, doit a9 _ONLY_TYPECHECK,
-   doit a10 last_query_successful, doit a11 UChannel.input_statehash)
+   doit a10 last_query_successful, doit a11 UChannel.input_statehash,
+   doit a12 command_handler)
 ;;
 
 let next_state_name =

--- a/toploop/version.ml
+++ b/toploop/version.ml
@@ -1,2 +1,2 @@
 let version = "0.7.39" ;;
-let source_hash = "f0cdf26b13b58be1459ca63011a749130b780431";;
+let source_hash = "c154fa33bc19f853a7b2f069cd4f31120f34536f";;

--- a/toploop/version.ml
+++ b/toploop/version.ml
@@ -1,2 +1,2 @@
-let version = "0.7.39" ;;
+let version = "0.7.40" ;;
 let source_hash = "c154fa33bc19f853a7b2f069cd4f31120f34536f";;

--- a/webui/package.json
+++ b/webui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "makam-webui",
-  "version": "0.7.39",
+  "version": "0.7.40",
   "description": "CodeMirror-based WebUI for Makam",
   "main": "makam-webui-bundle.js",
   "scripts": {


### PR DESCRIPTION
Fixes a bug with #108, where transformer registration was not working correctly in the Makam web service. Switched to a more robust way to register the toplevel command handler.

Also includes two extra helper predicates to be used in an upcoming post.